### PR TITLE
feat(docker): add production Docker image and compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Dependencies — reinstalled inside the image
+node_modules/
+client/node_modules/
+
+# Build output — rebuilt inside the image
+client/dist/
+dist/
+
+# Persistent runtime state — must not be baked into the image; mount as volumes instead
+server/data/
+server/gcode/
+
+# Version control / editor / OS cruft
+.git/
+.gitignore
+.DS_Store
+.vscode/
+.idea/
+
+# Claude Code / docs / project meta — not needed at runtime
+.claude/
+CLAUDE.md
+docs/
+ARCHITECTURE.md
+README.md
+LICENSE
+*.md
+
+# Secrets and local env
+.env
+.env.*
+
+# Misc data files that shouldn't ship in the image
+*.csv
+*.docx
+
+# Windows-only helper script
+update.bat
+
+# Docker files themselves (no need to copy into build context recursively)
+Dockerfile
+.dockerignore
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1
+
+# ---- Stage 1: server dependencies -----------------------------------------
+# Installed with devDependencies so the `postinstall` (patch-package) step can
+# apply patches/sdcp+0.5.4.patch to node_modules/sdcp. Pruned to production
+# deps afterward so the patched files ship but jest/supertest/patch-package don't.
+FROM node:22-bookworm-slim AS server-deps
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+COPY package.json package-lock.json ./
+COPY patches ./patches
+RUN npm ci
+RUN npm prune --omit=dev
+
+# ---- Stage 2: build the React client ---------------------------------------
+FROM node:22-bookworm-slim AS client-build
+WORKDIR /app/client
+COPY client/package.json client/package-lock.json ./
+RUN npm ci
+COPY client/ ./
+RUN npm run build
+
+# ---- Stage 3: production runtime -------------------------------------------
+FROM node:22-bookworm-slim AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY package.json ./
+COPY --from=server-deps /app/node_modules ./node_modules
+COPY server ./server
+COPY --from=client-build /app/client/dist ./client/dist
+
+# Persistent state — mount volumes here in production (see docker-compose.yml)
+RUN mkdir -p server/data server/gcode
+
+EXPOSE 3000
+
+CMD ["node", "server/index.js"]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,51 @@ npm run dev
 
 ## Installation (Production)
 
+### Option A — Docker (recommended)
+
+Requires [Docker](https://docs.docker.com/get-docker/) (and Compose, bundled with Docker Desktop and modern Docker Engine installs). This runs the same production build described in Option B, packaged into a container — no local Node.js install needed on the host.
+
+```bash
+git clone https://github.com/joeltelling/print-farm-manager.git
+cd print-farm-manager
+docker compose up -d --build
+```
+
+This builds the image (compiling `better-sqlite3` and building the React client inside the container) and starts it in the background, restarting automatically on crash or host reboot. The SQLite database, hourly backups, and uploaded G-code files are stored in the named Docker volumes `farm-data` and `farm-gcode`, so they survive container rebuilds and updates.
+
+Open `http://localhost:3000` in a browser, or replace `localhost` with the machine's LAN IP to access it from any device on the network.
+
+**Updating** to a new version:
+
+```bash
+git pull
+docker compose up -d --build
+```
+
+**Useful commands:**
+
+| Command | What it does |
+|---|---|
+| `docker compose logs -f` | Follow server logs |
+| `docker compose stop` | Stop the container (data is preserved) |
+| `docker compose up -d` | Start it again |
+| `docker compose down` | Stop and remove the container (volumes are preserved) |
+
+Without Compose, the equivalent `docker run` is:
+
+```bash
+docker build -t print-farm-manager .
+docker run -d --name print-farm-manager --restart unless-stopped \
+  -p 3000:3000 \
+  -v farm-data:/app/server/data \
+  -v farm-gcode:/app/server/gcode \
+  print-farm-manager
+```
+
+> Same security note as above applies inside Docker: only publish port 3000 to interfaces on your trusted LAN, not `0.0.0.0` on an internet-facing host.
+
+### Option B — Bare metal (Node.js on the host)
+
 For a full walkthrough covering prerequisites, network setup, auto-start with PM2, backup, updating, and troubleshooting on both Windows and macOS, see the **[Installation Guide](docs/installation.md)**.
 
 The short version:
@@ -132,7 +177,9 @@ print-farm-manager/
 │       ├── bambu.js       # MQTT + FTPS
 │       └── klipper.js     # Moonraker REST
 ├── client/               # React + Vite frontend
-└── docs/                 # Full documentation
+├── docs/                 # Full documentation
+├── Dockerfile            # Multi-stage production image (build client + server, run on Node 22)
+└── docker-compose.yml    # Production container with persistent data/gcode volumes
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  print-farm-manager:
+    build: .
+    image: print-farm-manager:latest
+    container_name: print-farm-manager
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - farm-data:/app/server/data
+      - farm-gcode:/app/server/gcode
+
+volumes:
+  farm-data:
+  farm-gcode:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ---
 
+## 2026-07-03 — Docker production deployment
+
+Added a container-based path to run the app in production, as an alternative to the bare-metal + PM2 setup. Requested to simplify deployment (no host Node.js/build-tooling install, consistent environment across machines) without changing any Phase 1 conventions — no DB migration system was introduced, and the SQLite/`better-sqlite3` synchronous-API convention is unaffected since the container just runs the existing `server/index.js` entry point.
+
+Three-stage multi-stage `Dockerfile`:
+1. `server-deps` — installs root `node_modules` with dev dependencies present so the `postinstall` script (`patch-package`) can apply `patches/sdcp+0.5.4.patch`; then `npm prune --omit=dev` drops `jest`/`supertest`/`patch-package` from what gets copied forward. Base image `node:22-bookworm-slim` matches the README's Node 22 LTS requirement; `python3 make g++` installed for `better-sqlite3`'s native build.
+2. `client-build` — `npm ci` + `npm run build` for the Vite client, same as the existing bare-metal `npm run build` step.
+3. `runtime` — copies the pruned `node_modules`, `server/`, and the built `client/dist` into a clean `node:22-bookworm-slim` image; no build tools in the final image. `server/data` (SQLite DB + hourly backups) and `server/gcode` (uploaded G-code) are created as mount points for volumes so they persist across container rebuilds.
+
+`docker-compose.yml` wires up named volumes `farm-data` and `farm-gcode` for those two directories, publishes port 3000, and sets `restart: unless-stopped`.
+
+`.dockerignore` excludes `node_modules`, build output, `server/data`/`server/gcode` (must come from volumes, not the image), git/editor/OS files, and docs/project-meta files not needed at runtime.
+
+Verified locally: `docker compose up -d --build` builds cleanly, `/api/health` and the served client both return 200, and `jest`/`supertest`/`patch-package` are absent from the running container's `node_modules` while the `sdcp` patch is present.
+
+### Changes
+- `Dockerfile` (new): multi-stage build described above.
+- `docker-compose.yml` (new): production service definition with persistent volumes.
+- `.dockerignore` (new): build-context exclusions.
+- `README.md`: "Installation (Production)" now leads with a Docker option (recommended) alongside the existing bare-metal option; Project Structure block lists the new files.
+
+No new runtime dependencies — `patch-package` was already a devDependency (used by the existing bare-metal `npm install` too); the Dockerfile just isolates when its output is needed vs. pruned.
+
+---
+
 ## 2026-07-02 — CSV import: Core One printers no longer inferred as Core 1L
 
 `inferModel()` in `server/routes/printers.js` listed the `CoreOne_` prefix in both the `c1l` and `c1` patterns, and `c1l` was checked first — so a printer named `CoreOne_01` imported as a Core 1L instead of a Core One. The `c1l` pattern now uses `CoreOneL_` (alongside `Core1L_` and `C1L `); `CoreOne_` correctly falls through to `c1`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,9 @@ print-farm-manager/
 │   │       ├── Projects.jsx       # Project/Part/G-code management
 │   │       └── Jobs.jsx           # Job queue table
 ├── docs/                 # This folder
-└── ARCHITECTURE.md       # Full product spec and phase planning
+├── ARCHITECTURE.md       # Full product spec and phase planning
+├── Dockerfile            # Multi-stage production image
+└── docker-compose.yml    # Production container + persistent volumes
 ```
 
 ## Development Phases

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,8 @@
 
 This guide covers installing Print Farm Manager on a dedicated machine that sits on the same local network as your printer fleet. Steps that differ between **Windows** and **macOS** are clearly labelled. Where instructions are the same on both platforms, no label is shown.
 
+> **Running in Docker instead?** This guide covers a bare-metal Node.js + PM2 install. If you'd rather run the app in a container (no local Node.js or build tooling required), see the **Docker** section in the [README](../README.md#installation-production) — it uses the `Dockerfile` and `docker-compose.yml` at the repo root and handles everything below (build, port, auto-restart, persistent data) through Docker instead.
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- Adds a multi-stage `Dockerfile` (server deps + patch-package, client build, slim runtime) so the app can run in production without a host Node.js/build-tooling install.
- Adds `docker-compose.yml` with named volumes for `server/data` (SQLite DB + hourly backups) and `server/gcode` (uploaded files), and `restart: unless-stopped`.
- Adds `.dockerignore` to keep `node_modules`, build output, and persistent-data directories out of the image.
- Updates `README.md`, `docs/installation.md`, `docs/README.md`, and `docs/CHANGELOG.md` to document the new Docker path alongside the existing bare-metal + PM2 install.

No application code changed — same `server/index.js` entry point, same `PORT` env var, same data paths (`server/data`, `server/gcode`).

## Test plan
- [x] `docker compose up -d --build` builds cleanly (verified locally)
- [x] `patch-package` applies the `sdcp` patch during build; `jest`/`supertest`/`patch-package` are absent from the final runtime image's `node_modules`
- [x] `GET /api/health` returns `200` from the running container
- [x] Served React client returns `200` at `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)