### PR TITLE
feat(drivers): add OctoPrint as a supported printer brand (Phase 6D)

### DIFF
--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -19,6 +19,7 @@ const CONNECTOR_OPTIONS = [
   { value: 'elegoo-centauri2', label: 'Elegoo CC2 (MQTT)' },
   { value: 'bambu',            label: 'Bambu (MQTT)' },
   { value: 'klipper',          label: 'Klipper (Moonraker)' },
+  { value: 'octoprint',        label: 'OctoPrint' },
 ];
 const CONNECTOR_LABEL = {
   'prusa':            'Prusa (PrusaLink)',
@@ -26,6 +27,7 @@ const CONNECTOR_LABEL = {
   'elegoo-centauri2': 'Elegoo CC2 (MQTT)',
   'bambu':            'Bambu (MQTT)',
   'klipper':          'Klipper (Moonraker)',
+  'octoprint':        'OctoPrint',
 };
 // Connector types that do not use an API key
 const NO_API_KEY_TYPES = new Set(['elegoo-centauri', 'klipper']);
@@ -37,6 +39,7 @@ const CREDENTIAL_HELP = {
   'elegoo-centauri2': 'Enable LAN mode on the printer. The Access Code and Serial Number are shown on the printer\'s network settings screen.',
   'bambu':            'Enable LAN Mode on the printer first. The Access Code is on the printer screen under Settings → WLAN; the Serial Number is under Settings → Device.',
   'klipper':          'No API key needed — just the IP of the machine running Moonraker. Port 7125 is used automatically.',
+  'octoprint':        'API Key: in OctoPrint under Settings → API. If OctoPrint isn\'t on port 80 (commonly :5000), include the port in the IP field, e.g. 192.168.1.50:5000.',
 };
 
 export default function Settings() {
@@ -740,7 +743,7 @@ export default function Settings() {
                 value={addForm.name}
                 onChange={e => setAddForm(p => ({ ...p, name: e.target.value }))}
                 required
-                placeholder={addForm.type === 'elegoo-centauri' ? 'Centauri_01' : addForm.type === 'elegoo-centauri2' ? 'CC2_01' : addForm.type === 'bambu' ? 'Bambu_X1C_01' : addForm.type === 'klipper' ? 'Voron_01' : 'MK4S_11'}
+                placeholder={addForm.type === 'elegoo-centauri' ? 'Centauri_01' : addForm.type === 'elegoo-centauri2' ? 'CC2_01' : addForm.type === 'bambu' ? 'Bambu_X1C_01' : addForm.type === 'klipper' ? 'Voron_01' : addForm.type === 'octoprint' ? 'OctoPi_01' : 'MK4S_11'}
                 style={inputStyle}
               />
             </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,32 @@ The Elegoo Centauri Carbon 2 driver originally uploaded files by having the prin
 
 ---
 
+## 2026-07-03 — OctoPrint connector (Phase 6D)
+
+Added OctoPrint as a supported "Add Printer" brand, following the driver abstraction from Phase 6A. Covers any printer managed by OctoPrint/OctoPi (not brand-specific — a Prusa, Ender, or Voron all look the same to the farm manager once behind OctoPrint's REST API).
+
+`server/drivers/octoprint.js` implements the shared driver interface (`getStatus`, `uploadAndPrint`, `cancelJob`, `checkIfPrinting`) against OctoPrint's REST API (`X-Api-Key` auth, plain HTTP polling — same stateless pattern as `prusa.js`/`klipper.js`, no persistent connection needed):
+
+- Status: `GET /api/printer` (`state.flags`) + `GET /api/job` (`progress.completion`, `progress.printTimeLeft`, `job.file.name`).
+- Upload: `POST /api/files/local` (multipart) with `select=true` and `print=true` — uploads and starts the print in a single call. A 409 (file mid-print) maps to `UPLOAD_CONFLICT`, same retry/backoff handling as Prusa.
+- Cancel: `POST /api/job` `{"command":"cancel"}` — actually implemented, unlike PrusaLink's stub, since OctoPrint exposes a working cancel endpoint.
+- FINISHED detection required a heuristic: OctoPrint doesn't hold a persistent "just completed" state like PrusaLink/Moonraker, so the driver infers it from not-printing + a loaded job file + `completion === 100`. Documented in `docs/multi-brand.md`.
+- No dedicated port field added — OctoPrint commonly runs on `:5000` rather than `:80`, so the operator includes the port in the existing `ip` field (e.g. `192.168.1.50:5000`), same as Prusa's `ip` field already supports.
+
+### Changes
+- `server/drivers/octoprint.js` (new): driver implementation.
+- `server/drivers/index.js`: registered `'octoprint'` in the driver `LOADERS` map.
+- `server/routes/models.js`: added `'octoprint'` to `VALID_CONNECTORS`.
+- `client/src/pages/Settings.jsx`: added OctoPrint to the brand dropdown, credential help text, and name placeholder. No change needed to `NO_API_KEY_TYPES` — OctoPrint requires a real API key.
+- `server/tests/octoprint-driver.test.js` (new): 21 tests covering status mapping (including the FINISHED heuristic), upload conflict handling, cancel, and driver registry lookup.
+- `docs/multi-brand.md`, `docs/README.md`: documented the new connector.
+
+No DB schema changes and no changes to `Fleet.jsx`/`Dashboard.jsx` — both already derive brand/model display purely from the `printer_models` table (`connector` + `model_id`), which is populated via the existing Settings → Printer Models UI. No new npm dependencies — reuses `axios` and `form-data`, already present for the Klipper driver.
+
+Verified in a `node:22-bookworm-slim` container (matching the project's Docker base image) rather than the host: full server test suite passes (378 tests, including the 21 new OctoPrint driver tests).
+
+---
+
 ## 2026-07-03 — Docker production deployment
 
 Added a container-based path to run the app in production, as an alternative to the bare-metal + PM2 setup. Requested to simplify deployment (no host Node.js/build-tooling install, consistent environment across machines) without changing any Phase 1 conventions — no DB migration system was introduced, and the SQLite/`better-sqlite3` synchronous-API convention is unaffected since the container just runs the existing `server/index.js` entry point.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Print Farm Manager — Documentation
 
-A locally-hosted web app for managing a multi-brand 3D printer farm. Replaces manual USB job distribution with centralized status monitoring and automated job dispatch. Supports Prusa (PrusaLink), Elegoo Centauri (SDCP), and Bambu (MQTT) printers.
+A locally-hosted web app for managing a multi-brand 3D printer farm. Replaces manual USB job distribution with centralized status monitoring and automated job dispatch. Supports Prusa (PrusaLink), Elegoo Centauri (SDCP), Bambu (MQTT), Klipper (Moonraker), and OctoPrint printers.
 
 ## Quick Start
 
@@ -80,5 +80,6 @@ print-farm-manager/
 | 6A | Complete | Driver abstraction layer — Prusa extracted into `server/drivers/prusa.js`; registry wired |
 | 6B | Complete | Elegoo Centauri Carbon SDCP driver via `sdcp` package; UI and route changes for non-Prusa brands |
 | 6C | Complete | Klipper (Moonraker) driver — Voron and all Klipper-firmware printers via plain HTTP on port 7125 |
+| 6D | Complete | OctoPrint driver — any OctoPrint/OctoPi-managed printer via OctoPrint's own REST API |
 
 See [ARCHITECTURE.md](../ARCHITECTURE.md) for full product spec.

--- a/docs/multi-brand.md
+++ b/docs/multi-brand.md
@@ -1,6 +1,8 @@
 # Multi-Brand Printer Support
 
 > **Phase 6C added (2026-04-20).** Klipper (Moonraker) connector complete — covers Voron and all Klipper-firmware printers. Prusa Link, Elegoo SDCP, Bambu, and Klipper are all fully supported.
+>
+> **Phase 6D added (2026-07-03).** OctoPrint connector complete — covers any printer running OctoPrint/OctoPi (Prusa, Ender, Voron, or otherwise), via OctoPrint's own REST API rather than the printer firmware's native protocol.
 
 ## Overview
 
@@ -68,8 +70,9 @@ Each connector family covers all printer models that share the same protocol:
 | **Prusa Link** | PrusaLink REST API (HTTP polling) | MK4, XL, and any future Prusa models |
 | **Elegoo SDCP** | SDCP WebSocket V3.0.0 (port 3030) | Centauri Carbon, Centauri Carbon 2 |
 | **Klipper (Moonraker)** | Moonraker REST API (HTTP polling, port 7125) | Voron and any Klipper-firmware printer |
+| **OctoPrint** | OctoPrint REST API (HTTP polling, operator-supplied port) | Any printer running OctoPrint/OctoPi |
 
-The `printer.type` DB column stores the connector identifier (`prusa`, `elegoo-centauri`, `bambu`, or `klipper`). The model column (`centauri-carbon`, etc.) is used only for display grouping in the UI.
+The `printer.type` DB column stores the connector identifier (`prusa`, `elegoo-centauri`, `bambu`, `klipper`, or `octoprint`). The model column (`centauri-carbon`, etc.) is used only for display grouping in the UI.
 
 ---
 
@@ -148,6 +151,20 @@ Uses the `sdcp` npm package (blakejrobinson) which wraps the SDCP WebSocket prot
 - [RemmyLee/carbon](https://github.com/RemmyLee/carbon) — developer documentation for SDCP
 
 ---
+
+## OctoPrint Notes
+
+OctoPrint is a plain HTTP REST API (no persistent connection, `X-Api-Key` auth), so `server/drivers/octoprint.js` follows the Prusa/Klipper stateless-polling pattern rather than the Elegoo/Bambu persistent-connection pattern.
+
+- `GET /api/printer` → `state.flags` (`operational`, `printing`, `paused`, `pausing`, `cancelling`, `error`, `closedOrError`) is the canonical status source.
+- `GET /api/job` → `progress.completion` (0–100), `progress.printTimeLeft` (seconds), `job.file.name` supply progress and the current filename.
+- Upload: `POST /api/files/local` (multipart) with `select=true` and `print=true` form fields — uploads and starts the print in one call, unlike PrusaLink (separate header) or Moonraker (separate `print` field only).
+- Cancel: `POST /api/job` with `{"command": "cancel"}` — actually implemented (unlike Prusa's stub, since OctoPrint exposes a reliable cancel endpoint).
+- No dedicated port field: OctoPrint commonly runs on `:5000` rather than `:80`, so the operator includes the port directly in the `ip` field (e.g. `192.168.1.50:5000`), same as how Prusa's `ip` field already accepts a host:port pair.
+
+### FINISHED detection
+
+Unlike PrusaLink (`FINISHED` state) or Moonraker (`complete` state), OctoPrint has no persistent "just completed" flag — after a print finishes it reports the same `operational` flags as a printer that never printed. The driver detects completion by combining flags with the job endpoint: not printing/paused, a job file is still loaded, and `progress.completion === 100`. This condition clears itself once the next print starts (completion resets), and `poller.js` only reacts to it once since it only fires `statusChange` on a DB status transition — so no additional per-printer state needs to live in the driver.
 
 ## G-Code Filename Parsing
 

--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -12,6 +12,7 @@ const LOADERS = {
   'elegoo-centauri2': () => require('./elegoo-centauri2'),
   'bambu':            () => require('./bambu'),
   'klipper':          () => require('./klipper'),
+  'octoprint':        () => require('./octoprint'),
 };
 
 function getDriver(type) {

--- a/server/drivers/octoprint.js
+++ b/server/drivers/octoprint.js
@@ -1,0 +1,133 @@
+// OctoPrint driver — OctoPrint REST API (HTTP polling)
+// Implements the shared driver interface: getStatus, uploadAndPrint, cancelJob, checkIfPrinting
+//
+// All functions are async and take a `printer` DB row as the first argument.
+// uploadAndPrint receives a resolved absolute path to the G-code file on disk.
+//
+// Reference: https://docs.octoprint.org/en/main/api/index.html
+// printer.ip may include a port (e.g. "octopi.local:5000") — OctoPrint commonly
+// runs behind its bundled server on :5000 rather than :80, so no port is assumed.
+
+const axios = require('axios');
+const fs = require('fs');
+const FormData = require('form-data');
+
+function headers(printer) {
+  return { 'X-Api-Key': printer.api_key };
+}
+
+// ─── Status ─────────────────────────────────────────────────────────────────
+
+// Returns { status, progress, timeRemaining, currentFile }
+// status is a canonical string: IDLE | PRINTING | FINISHED | PAUSED | ERROR | OFFLINE | UNKNOWN
+//
+// OctoPrint has no persistent "just finished" state like PrusaLink/Moonraker — after a
+// print completes it reports the same `operational` flags as a printer that never printed.
+// We detect completion by combining the flags with /api/job's leftover progress: not
+// printing/paused, a job file is still loaded, and completion sits at 100%. This condition
+// naturally stops being true once the operator (or scheduler) starts the next print, and
+// poller.js only reacts to it once since the DB status only changes on the transition.
+async function getStatus(printer) {
+  try {
+    const [printerRes, jobRes] = await Promise.all([
+      axios.get(`http://${printer.ip}/api/printer`, { headers: headers(printer), timeout: 8000 }),
+      axios.get(`http://${printer.ip}/api/job`, { headers: headers(printer), timeout: 8000 }),
+    ]);
+
+    const flags = printerRes.data?.state?.flags || {};
+    const job = jobRes.data || {};
+    const completion = job.progress?.completion ?? null;
+    const hasJobFile = !!job.job?.file?.name;
+
+    let status;
+    if (flags.error || flags.closedOrError) {
+      status = 'ERROR';
+    } else if (flags.printing || flags.pausing || flags.cancelling) {
+      status = 'PRINTING';
+    } else if (flags.paused) {
+      status = 'PAUSED';
+    } else if (flags.operational && hasJobFile && completion === 100) {
+      status = 'FINISHED';
+    } else if (flags.operational) {
+      status = 'IDLE';
+    } else {
+      status = 'UNKNOWN';
+    }
+
+    const progress = (status === 'PRINTING') ? completion : null;
+    const timeRemaining = (status === 'PRINTING') ? (job.progress?.printTimeLeft ?? null) : null;
+    const currentFile = (status === 'PRINTING' && hasJobFile) ? job.job.file.name : null;
+
+    return { status, progress, timeRemaining, currentFile };
+  } catch (_) {
+    return { status: 'OFFLINE', progress: null, timeRemaining: null, currentFile: null };
+  }
+}
+
+// ─── Upload & Print ──────────────────────────────────────────────────────────
+
+// Uploads the G-code file to OctoPrint's "local" file location and starts the print in
+// one call (OctoPrint supports select+print as multipart form fields, unlike PrusaLink
+// which needs a header on the upload and Moonraker which needs a separate print field).
+// Throws UPLOAD_CONFLICT if OctoPrint refuses because the same file is mid-print.
+async function uploadAndPrint(printer, gcodeFullPath, filename) {
+  const form = new FormData();
+  form.append('file', fs.createReadStream(gcodeFullPath), { filename });
+  form.append('select', 'true');
+  form.append('print', 'true');
+
+  try {
+    await axios.post(
+      `http://${printer.ip}/api/files/local`,
+      form,
+      {
+        headers: { ...headers(printer), ...form.getHeaders() },
+        timeout: 300000, // 5 minutes — large files on slow networks
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
+      }
+    );
+  } catch (err) {
+    if (err.response?.status === 409) {
+      throw Object.assign(
+        new Error(`409 Conflict on upload — file likely mid-print on ${printer.name}`),
+        { code: 'UPLOAD_CONFLICT' }
+      );
+    }
+    throw err;
+  }
+}
+
+// ─── Cancel ──────────────────────────────────────────────────────────────────
+
+async function cancelJob(printer) {
+  try {
+    await axios.post(
+      `http://${printer.ip}/api/job`,
+      { command: 'cancel' },
+      { headers: headers(printer), timeout: 10000 }
+    );
+  } catch (err) {
+    console.warn(`[octoprint] Cancel failed for ${printer.name}: ${err.message}`);
+  }
+}
+
+// ─── Check if printing ────────────────────────────────────────────────────────
+
+// Returns true if the printer is currently PRINTING or PAUSED.
+// Used by the scheduler after an upload failure to detect the case where our
+// request timed out but the printer received the file and started printing anyway.
+async function checkIfPrinting(printer) {
+  try {
+    const response = await axios.get(`http://${printer.ip}/api/printer`, {
+      headers: headers(printer),
+      timeout: 8000,
+    });
+    const flags = response.data?.state?.flags || {};
+    return !!(flags.printing || flags.paused || flags.pausing || flags.cancelling);
+  } catch (_) {
+    return false;
+  }
+}
+
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting };

--- a/server/routes/models.js
+++ b/server/routes/models.js
@@ -2,7 +2,7 @@ const express = require('express');
 
 // Connectors are code-level — each requires a driver implementation.
 // This list is the authoritative set of valid connector values.
-const VALID_CONNECTORS = ['prusa', 'elegoo-centauri', 'elegoo-centauri2', 'bambu', 'klipper'];
+const VALID_CONNECTORS = ['prusa', 'elegoo-centauri', 'elegoo-centauri2', 'bambu', 'klipper', 'octoprint'];
 
 module.exports = (db) => {
   const router = express.Router();

--- a/server/tests/octoprint-driver.test.js
+++ b/server/tests/octoprint-driver.test.js
@@ -1,0 +1,241 @@
+// Unit tests for server/drivers/octoprint.js
+// All network calls are mocked — no real printers needed.
+
+jest.mock('axios');
+const axios = require('axios');
+
+const path = require('path');
+const fs = require('fs');
+const octoprint = require('../drivers/octoprint');
+
+const GCODE_DIR = path.join(__dirname, '..', 'gcode');
+
+const fakePrinter = { id: 1, name: 'OctoPi_01', ip: '192.168.1.240:5000', model: 'mk3s', type: 'octoprint', api_key: 'test-key' };
+
+const filesToClean = [];
+
+beforeAll(() => {
+  if (!fs.existsSync(GCODE_DIR)) fs.mkdirSync(GCODE_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  for (const p of filesToClean) {
+    try { fs.unlinkSync(p); } catch (_) {}
+  }
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+function createTestFile(filename) {
+  const filePath = path.join(GCODE_DIR, filename);
+  fs.writeFileSync(filePath, '; fake gcode');
+  filesToClean.push(filePath);
+  return filePath;
+}
+
+function printerResponse(flags) {
+  return { data: { state: { flags: { operational: true, printing: false, paused: false, pausing: false, cancelling: false, error: false, closedOrError: false, ready: true, ...flags } } } };
+}
+
+function jobResponse({ completion = null, printTimeLeft = null, filename = null } = {}) {
+  return {
+    data: {
+      progress: { completion, printTimeLeft },
+      job: { file: { name: filename } },
+    },
+  };
+}
+
+function mockPair(printerFlags, jobOpts) {
+  axios.get.mockImplementation((url) => {
+    if (url.includes('/api/printer')) return Promise.resolve(printerResponse(printerFlags));
+    if (url.includes('/api/job')) return Promise.resolve(jobResponse(jobOpts));
+    return Promise.reject(new Error(`unexpected url ${url}`));
+  });
+}
+
+// ─── getStatus ────────────────────────────────────────────────────────────────
+
+describe('getStatus', () => {
+  test('returns IDLE when operational with no job loaded', async () => {
+    mockPair({}, {});
+    const result = await octoprint.getStatus(fakePrinter);
+    expect(result.status).toBe('IDLE');
+    expect(result.progress).toBeNull();
+    expect(result.timeRemaining).toBeNull();
+  });
+
+  test('returns PRINTING with progress, time remaining, and current file', async () => {
+    mockPair({ printing: true }, { completion: 42, printTimeLeft: 600, filename: 'part.gcode' });
+    const result = await octoprint.getStatus(fakePrinter);
+    expect(result.status).toBe('PRINTING');
+    expect(result.progress).toBe(42);
+    expect(result.timeRemaining).toBe(600);
+    expect(result.currentFile).toBe('part.gcode');
+  });
+
+  test('returns PRINTING while cancelling (transitional state)', async () => {
+    mockPair({ cancelling: true }, { completion: 80, filename: 'part.gcode' });
+    const result = await octoprint.getStatus(fakePrinter);
+    expect(result.status).toBe('PRINTING');
+  });
+
+  test('returns PAUSED', async () => {
+    mockPair({ paused: true }, { completion: 30, filename: 'part.gcode' });
+    const result = await octoprint.getStatus(fakePrinter);
+    expect(result.status).toBe('PAUSED');
+  });
+
+  test('returns FINISHED when not printing, job file present, completion is 100', async () => {
+    mockPair({}, { completion: 100, filename: 'part.gcode' });
+    const result = await octoprint.getStatus(fakePrinter);
+    expect(result.status).toBe('FINISHED');
+    expect(result.progress).toBeNull();
+  });
+
+  test('returns IDLE (not FINISHED) when completion is 100 but no job file loaded', async () => {
+    mockPair({}, { completion: 100, filename: null });
+    const result = await octoprint.getStatus(fakePrinter);
+    expect(result.status).toBe('IDLE');
+  });
+
+  test('returns ERROR when error flag is set', async () => {
+    mockPair({ error: true }, {});
+    const result = await octoprint.getStatus(fakePrinter);
+    expect(result.status).toBe('ERROR');
+  });
+
+  test('returns ERROR when closedOrError flag is set', async () => {
+    mockPair({ operational: false, closedOrError: true }, {});
+    const result = await octoprint.getStatus(fakePrinter);
+    expect(result.status).toBe('ERROR');
+  });
+
+  test('returns UNKNOWN when not operational and no error flag', async () => {
+    mockPair({ operational: false }, {});
+    const result = await octoprint.getStatus(fakePrinter);
+    expect(result.status).toBe('UNKNOWN');
+  });
+
+  test('returns OFFLINE on network error', async () => {
+    axios.get.mockRejectedValue(new Error('ETIMEDOUT'));
+    const result = await octoprint.getStatus(fakePrinter);
+    expect(result.status).toBe('OFFLINE');
+    expect(result.progress).toBeNull();
+  });
+
+  test('queries /api/printer and /api/job with X-Api-Key header', async () => {
+    mockPair({}, {});
+    await octoprint.getStatus(fakePrinter);
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://192.168.1.240:5000/api/printer',
+      expect.objectContaining({ headers: { 'X-Api-Key': 'test-key' } })
+    );
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://192.168.1.240:5000/api/job',
+      expect.objectContaining({ headers: { 'X-Api-Key': 'test-key' } })
+    );
+  });
+});
+
+// ─── uploadAndPrint ───────────────────────────────────────────────────────────
+
+describe('uploadAndPrint', () => {
+  test('POSTs to /api/files/local with select and print form fields', async () => {
+    const filename = `octoprint_upload_${Date.now()}.gcode`;
+    const fullPath = createTestFile(filename);
+    axios.post.mockResolvedValueOnce({});
+
+    const FormData = require('form-data');
+    const appendSpy = jest.spyOn(FormData.prototype, 'append');
+
+    await octoprint.uploadAndPrint(fakePrinter, fullPath, filename);
+
+    const [url, , config] = axios.post.mock.calls[0];
+    expect(url).toBe('http://192.168.1.240:5000/api/files/local');
+    expect(config.headers['X-Api-Key']).toBe('test-key');
+
+    const appendedFields = appendSpy.mock.calls.map(([name, value]) => ({ name, value }));
+    expect(appendedFields).toContainEqual({ name: 'select', value: 'true' });
+    expect(appendedFields).toContainEqual({ name: 'print', value: 'true' });
+
+    appendSpy.mockRestore();
+  });
+
+  test('throws UPLOAD_CONFLICT on 409 response', async () => {
+    const filename = `octoprint_conflict_${Date.now()}.gcode`;
+    const fullPath = createTestFile(filename);
+    axios.post.mockRejectedValueOnce({ response: { status: 409 } });
+
+    await expect(octoprint.uploadAndPrint(fakePrinter, fullPath, filename))
+      .rejects.toMatchObject({ code: 'UPLOAD_CONFLICT' });
+  });
+
+  test('rethrows non-409 errors unchanged', async () => {
+    const filename = `octoprint_fail_${Date.now()}.gcode`;
+    const fullPath = createTestFile(filename);
+    axios.post.mockRejectedValueOnce(new Error('Request failed with status code 500'));
+
+    await expect(octoprint.uploadAndPrint(fakePrinter, fullPath, filename))
+      .rejects.toThrow('500');
+  });
+});
+
+// ─── cancelJob ─────────────────────────────────────────────────────────────────
+
+describe('cancelJob', () => {
+  test('POSTs cancel command to /api/job', async () => {
+    axios.post.mockResolvedValueOnce({});
+    await octoprint.cancelJob(fakePrinter);
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://192.168.1.240:5000/api/job',
+      { command: 'cancel' },
+      expect.objectContaining({ headers: { 'X-Api-Key': 'test-key' } })
+    );
+  });
+
+  test('swallows errors', async () => {
+    axios.post.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    await expect(octoprint.cancelJob(fakePrinter)).resolves.toBeUndefined();
+  });
+});
+
+// ─── checkIfPrinting ─────────────────────────────────────────────────────────
+
+describe('checkIfPrinting', () => {
+  test('returns true when printing', async () => {
+    axios.get.mockResolvedValueOnce(printerResponse({ printing: true }));
+    expect(await octoprint.checkIfPrinting(fakePrinter)).toBe(true);
+  });
+
+  test('returns true when paused', async () => {
+    axios.get.mockResolvedValueOnce(printerResponse({ paused: true }));
+    expect(await octoprint.checkIfPrinting(fakePrinter)).toBe(true);
+  });
+
+  test('returns false when idle', async () => {
+    axios.get.mockResolvedValueOnce(printerResponse({}));
+    expect(await octoprint.checkIfPrinting(fakePrinter)).toBe(false);
+  });
+
+  test('returns false when printer is unreachable', async () => {
+    axios.get.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    expect(await octoprint.checkIfPrinting(fakePrinter)).toBe(false);
+  });
+});
+
+// ─── Driver registry ──────────────────────────────────────────────────────────
+
+describe('driver registry', () => {
+  const { getDriver } = require('../drivers');
+
+  test('getDriver("octoprint") returns the octoprint driver', () => {
+    const driver = getDriver('octoprint');
+    expect(typeof driver.getStatus).toBe('function');
+    expect(typeof driver.uploadAndPrint).toBe('function');
+    expect(typeof driver.cancelJob).toBe('function');
+    expect(typeof driver.checkIfPrinting).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds OctoPrint/OctoPi as a supported "Add Printer" brand, following the driver abstraction from Phase 6A. Covers any printer managed by OctoPrint regardless of underlying firmware (Prusa, Ender, Voron, etc. all look identical to the farm manager once behind OctoPrint's REST API).
- `server/drivers/octoprint.js` implements the shared driver interface (`getStatus`, `uploadAndPrint`, `cancelJob`, `checkIfPrinting`) against OctoPrint's own REST API — plain HTTP + `X-Api-Key` auth, same stateless polling pattern as `prusa.js`/`klipper.js` (no persistent connection needed).
  - Status: `GET /api/printer` (`state.flags`) + `GET /api/job` (`progress.completion`, `progress.printTimeLeft`, `job.file.name`).
  - Upload: `POST /api/files/local` (multipart) with `select=true` and `print=true` — uploads and starts the print in one call. A 409 (file mid-print) maps to `UPLOAD_CONFLICT`, reusing the existing retry/backoff in the scheduler.
  - Cancel: `POST /api/job` `{"command":"cancel"}` — actually implemented, unlike PrusaLink's stub, since OctoPrint exposes a working cancel endpoint.
  - FINISHED detection required a heuristic: OctoPrint has no persistent "just completed" state like PrusaLink/Moonraker, so it's inferred from not-printing + a loaded job file + `completion === 100`. Documented in `docs/multi-brand.md`.
  - No dedicated port field — OctoPrint commonly runs on `:5000` rather than `:80`, so the operator includes the port in the existing `ip` field (e.g. `192.168.1.50:5000`), same as Prusa's `ip` field already supports.
- `server/drivers/index.js`, `server/routes/models.js`: registered the new `octoprint` connector.
- `client/src/pages/Settings.jsx`: added OctoPrint to the brand dropdown, credential help text, and name placeholder.
- `docs/multi-brand.md`, `docs/README.md`, `docs/CHANGELOG.md`: documented the new connector per project convention.

No DB schema changes, no changes to `Fleet.jsx`/`Dashboard.jsx` (both already derive brand/model display purely from the `printer_models` table). No new npm dependencies — reuses `axios` and `form-data`, already present for the Klipper driver.

## Test plan
- [x] `server/tests/octoprint-driver.test.js` (new): 21 tests covering status mapping (including the FINISHED heuristic), upload conflict handling, cancel, and driver registry lookup.
- [x] Full server test suite run inside a `node:22-bookworm-slim` container (matching the project's Docker base image): 378/378 passing.
- [x] End-to-end verified in a rebuilt Docker container via the browser: registered an OctoPrint model, added an OctoPrint printer through the UI, confirmed it saved correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)