### PR TITLE
ci: publish multi-arch Docker images to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:
@@ -18,6 +20,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -109,3 +112,26 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+  pr_test_build:
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build only (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: false
+          load: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,26 @@ permissions:
   packages: write
 
 jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run test suite
+        run: npm test
+
   build:
+    needs: test
     if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
@@ -114,6 +133,7 @@ jobs:
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
   pr_test_build:
+    needs: test
     if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,111 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runs_on: ubuntu-24.04
+            suffix: amd64
+          - platform: linux/arm64
+            runs_on: ubuntu-24.04-arm
+            suffix: arm64
+    runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.suffix }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule,pattern=edge
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=edge
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -87,23 +87,42 @@ npm run dev
 
 ### Option A — Docker (recommended)
 
-Requires [Docker](https://docs.docker.com/get-docker/) (and Compose, bundled with Docker Desktop and modern Docker Engine installs). This runs the same production build described in Option B, packaged into a container — no local Node.js install needed on the host.
+Requires [Docker](https://docs.docker.com/get-docker/) (and Compose, bundled with Docker Desktop and modern Docker Engine installs).
 
-```bash
-git clone https://github.com/joeltelling/print-farm-manager.git
-cd print-farm-manager
-docker compose up -d --build
+#### Quickest start — pull the published image
+
+No clone, no local build. A multi-arch image (`linux/amd64` + `linux/arm64`) is published automatically to GitHub Container Registry on every release — see [docs/docker-publish.md](docs/docker-publish.md). Save this as `docker-compose.yml`:
+
+```yaml
+services:
+  print-farm-manager:
+    image: ghcr.io/joeltelling/print-farm-manager:latest
+    container_name: print-farm-manager
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - farm-data:/app/server/data
+      - farm-gcode:/app/server/gcode
+
+volumes:
+  farm-data:
+  farm-gcode:
 ```
 
-This builds the image (compiling `better-sqlite3` and building the React client inside the container) and starts it in the background, restarting automatically on crash or host reboot. The SQLite database, hourly backups, and uploaded G-code files are stored in the named Docker volumes `farm-data` and `farm-gcode`, so they survive container rebuilds and updates.
+```bash
+docker compose up -d
+```
+
+This same file works as a drop-in stack in Portainer (**Stacks → Add stack → Web editor**, paste it in, deploy) — no repo checkout needed there either.
 
 Open `http://localhost:3000` in a browser, or replace `localhost` with the machine's LAN IP to access it from any device on the network.
 
-**Updating** to a new version:
+**Updating** to the latest published image:
 
 ```bash
-git pull
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
 **Useful commands:**
@@ -115,15 +134,33 @@ docker compose up -d --build
 | `docker compose up -d` | Start it again |
 | `docker compose down` | Stop and remove the container (volumes are preserved) |
 
-Without Compose, the equivalent `docker run` is:
+Pin to a specific release instead of always tracking `latest` by using a version tag, e.g. `ghcr.io/joeltelling/print-farm-manager:1.2.0`. `edge` tracks the latest build of `main` between releases.
+
+#### Building from source instead
+
+If you're testing local changes rather than running a release, clone the repo and build with the `docker-compose.yml` at its root (uses `build: .` instead of `image:`):
 
 ```bash
-docker build -t print-farm-manager .
+git clone https://github.com/joeltelling/print-farm-manager.git
+cd print-farm-manager
+docker compose up -d --build
+```
+
+Updating this path pulls new source and rebuilds:
+
+```bash
+git pull
+docker compose up -d --build
+```
+
+Without Compose, the equivalent `docker run` (published image) is:
+
+```bash
 docker run -d --name print-farm-manager --restart unless-stopped \
   -p 3000:3000 \
   -v farm-data:/app/server/data \
   -v farm-gcode:/app/server/gcode \
-  print-farm-manager
+  ghcr.io/joeltelling/print-farm-manager:latest
 ```
 
 > Same security note as above applies inside Docker: only publish port 3000 to interfaces on your trusted LAN, not `0.0.0.0` on an internet-facing host.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ---
 
+## 2026-07-04 — CI: gate Docker publishing on the test suite
+
+`.github/workflows/docker-publish.yml` could previously publish an image even if `server/tests/` was failing — nothing ran the suite. Added a `test` job (`npm ci` + `npm test` on `ubuntu-24.04`) that both `build` and the PR-only `pr_test_build` job now declare as a dependency (`needs: test`), so a red test suite blocks any image build, published or not. `merge` remains gated transitively via `needs: build`.
+
+### Changes
+- `.github/workflows/docker-publish.yml`: added the `test` job; `build` and `pr_test_build` now `needs: test`.
+- `docs/docker-publish.md`: documented the test gate and updated the job breakdown.
+
+---
+
 ## 2026-07-03 — README + install guide caught up to the OctoPrint connector
 
 PR #4 added the OctoPrint driver with full docs coverage in `multi-brand.md` but did not touch the two user-facing entry docs. Synced them: README gains an OctoPrint row in Supported Printers, `octoprint` in the CSV `type` list, corrected `api_key` requirements, and the full six-driver list in Project Structure (`elegoo-centauri2.js` and `octoprint.js` were missing); `docs/installation.md` credential table gains an OctoPrint row (API key from **Settings → API**, port included in the IP field, e.g. `:5000`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ npm run dev
 | [docs/CHANGELOG.md](CHANGELOG.md) | Dated log of all implemented features and changes |
 | [docs/multi-brand.md](multi-brand.md) | Phase 6 design — driver abstraction for non-Prusa brands (Elegoo Centauri Carbon) |
 | [docs/filaments.md](filaments.md) | Filament Library — admin-managed type and color lists, API endpoints, client usage |
+| [docs/docker-publish.md](docker-publish.md) | CI workflow that builds and publishes multi-arch Docker images to GHCR |
 
 ## Project Structure
 
@@ -63,6 +64,7 @@ print-farm-manager/
 │   │       ├── Projects.jsx       # Project/Part/G-code management
 │   │       └── Jobs.jsx           # Job queue table
 ├── docs/                 # This folder
+├── .github/workflows/    # CI — see docs/docker-publish.md
 ├── ARCHITECTURE.md       # Full product spec and phase planning
 ├── Dockerfile            # Multi-stage production image
 └── docker-compose.yml    # Production container + persistent volumes

--- a/docs/docker-publish.md
+++ b/docs/docker-publish.md
@@ -1,0 +1,70 @@
+# Docker Image Publishing (CI)
+
+## Purpose
+
+`.github/workflows/docker-publish.yml` builds and publishes the production Docker image (see the `Dockerfile` at the repo root) to GitHub Container Registry (GHCR) as `ghcr.io/<owner>/<repo>`, for both `linux/amd64` and `linux/arm64`, without requiring anyone to build locally or push manually.
+
+## Triggers
+
+| Event | Effect |
+|---|---|
+| Push to `main` | Rebuilds and republishes the `latest`/`edge` tag |
+| Push of a `v*` tag (e.g. `v1.2.0`) | Publishes semver tags (`1.2.0`, `1.2`) |
+| Daily schedule (`0 3 * * *`) | Rebuilds on top of the latest `node:22-bookworm-slim` base image, so security patches land even with no app changes |
+| `workflow_dispatch` | Manual run from the Actions tab |
+
+## Why native ARM runners instead of QEMU
+
+Building `linux/arm64` on an `amd64` GitHub-hosted runner normally means emulating ARM under QEMU via Buildx — it works, but `better-sqlite3`'s native module compile (`python3 make g++`, see `Dockerfile` stage `server-deps`) is CPU-heavy and QEMU emulation makes it dramatically slower, often the single biggest contributor to build time. GitHub now offers native `ubuntu-24.04-arm` runners, so the `arm64` leg of the matrix builds on real ARM hardware instead of emulating it.
+
+## Why split build + merge jobs
+
+Each matrix leg (`amd64` on `ubuntu-24.04`, `arm64` on `ubuntu-24.04-arm`) builds and pushes its own image **by digest only** — no tag, so nothing pullable exists yet from either leg alone. The digest is exported as a build artifact (`digests-amd64`, `digests-arm64`).
+
+A separate `merge` job then downloads both digest artifacts and runs `docker buildx imagetools create` to assemble a single multi-arch manifest list pointing at both digests, applying the real tags (`latest`, `edge`, semver) only at that point. This is the standard Buildx pattern for matrix-parallel multi-arch builds — it avoids one platform's build clobbering the tag before the other finishes, and avoids running both platforms in a single job (which would serialize them, or need QEMU for one anyway).
+
+## Image tags
+
+Tag rules come from `docker/metadata-action` in the `merge` job:
+
+| Git ref | Resulting tag(s) |
+|---|---|
+| Push to `main` | `latest`, `edge` |
+| Scheduled run | `edge` |
+| Tag `v1.2.0` | `1.2.0`, `1.2` |
+
+## Jobs
+
+```
+build (matrix: amd64, arm64)
+  1. Checkout
+  2. Set up Buildx
+  3. Log in to GHCR (GITHUB_TOKEN — no PAT needed)
+  4. Build + push image by digest (no tag yet)
+  5. Export the digest to /tmp/digests and upload as an artifact
+
+merge (needs: build)
+  1. Download both digest artifacts into /tmp/digests
+  2. Set up Buildx, log in to GHCR
+  3. Compute tags via docker/metadata-action
+  4. docker buildx imagetools create — assembles the multi-arch manifest list, applies tags, pushes
+  5. docker buildx imagetools inspect — sanity-check the pushed manifest
+```
+
+## Permissions
+
+`permissions: packages: write` on the workflow is what lets the built-in `GITHUB_TOKEN` push to GHCR — no separate PAT or secret is configured. `contents: read` is the default least-privilege for checkout.
+
+## One-time manual step: GHCR package visibility
+
+**GHCR packages are private by default on first push, even from a public repository.** After the first successful run, anyone trying to `docker pull ghcr.io/<owner>/<repo>` will get a permission error until visibility is fixed manually — this can't be set from the workflow itself.
+
+Fix it once, after the first push completes:
+
+1. Go to `github.com/users/<owner>/packages` (or the organization's Packages tab).
+2. Open the `<repo>` package → **Package settings**.
+3. Either set **Visibility** to Public, or link the package to the repository (**Manage Actions access** / connect repository) so it inherits the repo's visibility.
+
+## Local equivalent
+
+This workflow builds the same `Dockerfile` described in the [README](../README.md#installation-production) and used by `docker-compose.yml` — it doesn't change what gets built, only automates building it for two architectures and publishing it centrally instead of every user building it locally with `docker compose up --build`.

--- a/docs/docker-publish.md
+++ b/docs/docker-publish.md
@@ -10,8 +10,13 @@
 |---|---|
 | Push to `main` | Rebuilds and republishes the `latest`/`edge` tag |
 | Push of a `v*` tag (e.g. `v1.2.0`) | Publishes semver tags (`1.2.0`, `1.2`) |
+| Pull request targeting `main` | Runs the test suite and a build-only validation on both architectures — never touches GHCR |
 | Daily schedule (`0 3 * * *`) | Rebuilds on top of the latest `node:22-bookworm-slim` base image, so security patches land even with no app changes |
 | `workflow_dispatch` | Manual run from the Actions tab |
+
+## Test gate
+
+Every trigger — including PRs — runs the `test` job first: `npm ci` + `npm test` (the Jest suite in `server/tests/`) on `ubuntu-24.04`. Both `build` and `pr_test_build` declare `needs: test`, so a failing test suite blocks any image from being built at all, published or not. `merge` in turn depends on `build`, so the whole publish path is transitively gated on tests passing.
 
 ## Why native ARM runners instead of QEMU
 
@@ -36,19 +41,30 @@ Tag rules come from `docker/metadata-action` in the `merge` job:
 ## Jobs
 
 ```
-build (matrix: amd64, arm64)
+test (runs on every trigger)
+  1. Checkout
+  2. Set up Node.js 22
+  3. npm ci
+  4. npm test — Jest suite in server/tests/
+
+build (needs: test; matrix: amd64, arm64; skipped on pull_request)
   1. Checkout
   2. Set up Buildx
   3. Log in to GHCR (GITHUB_TOKEN — no PAT needed)
   4. Build + push image by digest (no tag yet)
   5. Export the digest to /tmp/digests and upload as an artifact
 
-merge (needs: build)
+merge (needs: build; skipped whenever build is skipped, e.g. on pull_request)
   1. Download both digest artifacts into /tmp/digests
   2. Set up Buildx, log in to GHCR
   3. Compute tags via docker/metadata-action
   4. docker buildx imagetools create — assembles the multi-arch manifest list, applies tags, pushes
   5. docker buildx imagetools inspect — sanity-check the pushed manifest
+
+pr_test_build (needs: test; matrix: amd64, arm64; only on pull_request)
+  1. Checkout
+  2. Set up Buildx
+  3. Build for each platform with push: false — validates the Dockerfile builds cleanly on both architectures, publishes nothing, needs no GHCR credentials
 ```
 
 ## Permissions


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/docker-publish.yml`: builds and publishes the existing `Dockerfile` to GHCR (`ghcr.io/joeltelling/print-farm-manager`) for `linux/amd64` and `linux/arm64`, using native ARM runners (`ubuntu-24.04-arm`) instead of QEMU emulation.
- Split `build`/`merge` job structure: each architecture builds and pushes by digest only, then a `merge` job assembles the multi-arch manifest list and applies tags (`latest`, `edge`, semver from `v*` tags). Triggers: push to `main`, `v*` tags, a daily schedule (picks up base-image security patches), and manual dispatch.
- Adds a `pull_request` trigger with a separate `pr_test_build` job — matrix build on both architectures with `push: false`, so PRs get the Dockerfile validated on both platforms without needing `packages: write` or touching the registry at all. The existing `build`/`merge` jobs skip on `pull_request` events.
- Adds a `test` job (`npm ci` + `npm test`) that both `build` and `pr_test_build` depend on (`needs: test`), so a failing `server/tests/` suite blocks any image from being built — publish path or PR validation alike.
- `README.md`: reworks the Docker installation section so the recommended path pulls `ghcr.io/joeltelling/print-farm-manager:latest` directly (drop-in compose file, also works as a Portainer stack) instead of requiring a clone + local build. The clone-and-build flow is kept as a secondary option for testing local changes.
- `docs/docker-publish.md` (new): documents the workflow — triggers, the native-ARM-runner rationale, why build/merge is split, the test gate, and a callout that GHCR packages are **private by default on first push** (even from a public repo) and need a manual visibility change afterward.

No DB or application code changes — CI and docs only.

## Test plan
- [x] Verified locally (in a `node:22-bookworm-slim` container matching the Dockerfile's base image) that `npm ci && npm test` passes: 378/378 tests.
- [x] Verified the Dockerfile builds and runs correctly via `docker compose up -d --build`, confirmed `/api/health` and the served client both return 200.
- [ ] First real run on `main` after merge will confirn the GHCR push + manifest merge end-to-end (cannot be tested from a fork without push access to `ghcr.io/joeltelling/*`) — the one-time package visibility step is documented in `docs/docker-publish.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)