### PR TITLE
fix(backup): reject path traversal in restore gcode_files keys

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ---
 
+## 2026-07-05 - Backup restore: reject path traversal in gcode_files
+
+`POST /api/backup/restore` wrote each `gcode_files` entry with `fs.writeFileSync(path.join(GCODE_DIR, key))`, where `key` is taken straight from the uploaded JSON. A key such as `../../server/scheduler.js` resolved outside `GCODE_DIR`, letting an uploaded backup overwrite arbitrary files with attacker-chosen contents. The DB insert side already reduced `filepath` to its basename, but the file write did not.
+
+Restore now validates every `gcode_files` key before writing anything and returns `400` if a key is not a bare filename (contains a path separator or resolves outside `GCODE_DIR`). A genuine export only ever uses bare filenames, so this rejects tampered bundles without affecting real ones.
+
+### Changes
+- `server/routes/backup.js`: validate `gcode_files` keys against `GCODE_DIR` before the write loop; reject traversal with `400`.
+- `server/tests/backup-restore.test.js` (new): traversal key rejected, `..` rejected, normal filename written inside `GCODE_DIR`.
+- `docs/api.md`: noted the restore filename constraint.
+
+---
+
 ## 2026-07-04 — CI: gate Docker publishing on the test suite
 
 `.github/workflows/docker-publish.yml` could previously publish an image even if `server/tests/` was failing — nothing ran the suite. Added a `test` job (`npm ci` + `npm test` on `ubuntu-24.04`) that both `build` and the PR-only `pr_test_build` job now declare as a dependency (`needs: test`), so a red test suite blocks any image build, published or not. `merge` remains gated transitively via `needs: build`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -586,6 +586,8 @@ Downloads a full farm snapshot as `farm-backup-YYYY-MM-DD.json`. Includes all 5 
 
 Replaces all farm data from a previously exported backup file. Clears the DB and rewrites all tables; gcode files are written to `server/gcode/`. Since `filepath` stores only the filename, no path rewriting is needed — the restored DB works correctly on any machine.
 
+Each `gcode_files` key must be a bare filename. A key containing a path separator or resolving outside `server/gcode/` is rejected with `400` before any data is written.
+
 **Request:** `multipart/form-data` with field `file` — the `.json` backup file. Max 500 MB.
 
 ```json

--- a/server/routes/backup.js
+++ b/server/routes/backup.js
@@ -80,9 +80,18 @@ module.exports = (db) => {
         return res.status(400).json({ error: 'Unrecognised backup format' });
       }
 
-      // Write gcode files to disk before the DB transaction
-      for (const [basename, b64] of Object.entries(backup.gcode_files || {})) {
-        fs.writeFileSync(path.join(GCODE_DIR, basename), Buffer.from(b64, 'base64'));
+      // Write gcode files to disk before the DB transaction. Keys come from the uploaded
+      // backup; a genuine one only ever holds bare filenames, so reject anything that
+      // isn't one (path separators, "..") before writing rather than after.
+      const gcodeFileEntries = Object.entries(backup.gcode_files || {});
+      const gcodeRoot = path.resolve(GCODE_DIR);
+      for (const [name] of gcodeFileEntries) {
+        if (path.basename(name) !== name || path.dirname(path.resolve(gcodeRoot, name)) !== gcodeRoot) {
+          return res.status(400).json({ error: `Invalid gcode filename in backup: ${name}` });
+        }
+      }
+      for (const [name, b64] of gcodeFileEntries) {
+        fs.writeFileSync(path.join(gcodeRoot, name), Buffer.from(b64, 'base64'));
       }
 
       const restore = db.transaction(() => {

--- a/server/tests/backup-restore.test.js
+++ b/server/tests/backup-restore.test.js
@@ -4,8 +4,6 @@ const path     = require('path');
 const fs       = require('fs');
 const Database = require('better-sqlite3');
 
-const backupRouter = require('../routes/backup');
-
 const GCODE_DIR = path.join(__dirname, '..', 'gcode');
 
 // Restore prepares each table's INSERT eagerly, so the columns it names must exist even
@@ -43,7 +41,11 @@ function makeDb() {
   return db;
 }
 
+// backup.js builds its router at module scope, so a fresh module instance is loaded per
+// app to avoid stacking /restore handlers (and their DBs) across tests.
 function makeApp() {
+  let backupRouter;
+  jest.isolateModules(() => { backupRouter = require('../routes/backup'); });
   const app = express();
   app.use(express.json());
   app.use('/api/backup', backupRouter(makeDb()));

--- a/server/tests/backup-restore.test.js
+++ b/server/tests/backup-restore.test.js
@@ -1,0 +1,102 @@
+const request  = require('supertest');
+const express  = require('express');
+const path     = require('path');
+const fs       = require('fs');
+const Database = require('better-sqlite3');
+
+const backupRouter = require('../routes/backup');
+
+const GCODE_DIR = path.join(__dirname, '..', 'gcode');
+
+// Restore prepares each table's INSERT eagerly, so the columns it names must exist even
+// though these tests only send empty row arrays. Payloads with empty arrays skip the
+// inserts; the AUTOINCREMENT keys back the sqlite_sequence resync.
+function makeDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE printers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, ip TEXT, api_key TEXT,
+      group_name TEXT, type TEXT, model TEXT, status TEXT, is_held INTEGER,
+      is_active INTEGER, created_at INTEGER, decommissioned_at INTEGER,
+      decommission_note TEXT, job_name TEXT, job_progress REAL, job_time_remaining INTEGER
+    );
+    CREATE TABLE projects (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, status TEXT,
+      priority INTEGER, created_at INTEGER, updated_at INTEGER
+    );
+    CREATE TABLE parts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, project_id INTEGER, name TEXT, target_qty INTEGER,
+      completed_qty INTEGER, status TEXT, created_at INTEGER, updated_at INTEGER, sort_order INTEGER
+    );
+    CREATE TABLE gcodes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, part_id INTEGER, printer_model TEXT, filename TEXT,
+      filepath TEXT, parts_per_plate INTEGER, est_print_secs INTEGER, created_at INTEGER
+    );
+    CREATE TABLE jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, part_id INTEGER, printer_id INTEGER, gcode_id INTEGER,
+      parts_per_plate INTEGER, status TEXT, started_at INTEGER, finished_at INTEGER, created_at INTEGER
+    );
+    CREATE TABLE printer_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, printer_id INTEGER, event_type TEXT, note TEXT, created_at INTEGER
+    );
+  `);
+  return db;
+}
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/backup', backupRouter(makeDb()));
+  return app;
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(GCODE_DIR)) fs.mkdirSync(GCODE_DIR, { recursive: true });
+});
+
+function post(app, backup) {
+  return request(app)
+    .post('/api/backup/restore')
+    .attach('file', Buffer.from(JSON.stringify(backup)), 'backup.json');
+}
+
+describe('POST /api/backup/restore — gcode_files path handling', () => {
+  const leaked = path.resolve(GCODE_DIR, '..', '..', 'pwned-by-test.js');
+
+  afterEach(() => {
+    for (const p of [leaked, path.join(GCODE_DIR, 'pwned-by-test.js'), path.join(GCODE_DIR, 'safe.gcode')]) {
+      if (fs.existsSync(p)) fs.unlinkSync(p);
+    }
+  });
+
+  test('rejects a traversal key and writes nothing outside GCODE_DIR', async () => {
+    const res = await post(makeApp(), {
+      version: 1,
+      printers: [],
+      gcode_files: { '../../pwned-by-test.js': Buffer.from('owned').toString('base64') },
+    });
+
+    expect(res.status).toBe(400);
+    expect(fs.existsSync(leaked)).toBe(false);
+  });
+
+  test('rejects a bare ".." key', async () => {
+    const res = await post(makeApp(), {
+      version: 1,
+      printers: [],
+      gcode_files: { '..': Buffer.from('owned').toString('base64') },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('writes a normal filename inside GCODE_DIR', async () => {
+    const res = await post(makeApp(), {
+      version: 1,
+      printers: [], projects: [], parts: [], gcodes: [], jobs: [], printer_events: [],
+      gcode_files: { 'safe.gcode': Buffer.from('hello').toString('base64') },
+    });
+
+    expect(res.status).toBe(200);
+    expect(fs.readFileSync(path.join(GCODE_DIR, 'safe.gcode'), 'utf8')).toBe('hello');
+  });
+});


### PR DESCRIPTION
## Problem

`POST /api/backup/restore` writes each `gcode_files` entry to disk with:

```js
fs.writeFileSync(path.join(GCODE_DIR, basename), Buffer.from(b64, 'base64'));
```

`basename` is the object key taken directly from the uploaded backup JSON. It is never checked, so a key like `../../server/scheduler.js` resolves outside `GCODE_DIR`. A crafted backup file can therefore overwrite arbitrary files the process can write, with attacker-chosen contents. Because the server `require()`s files from `server/`, that includes overwriting `poller.js`/`scheduler.js` and gaining code execution on the next start, or replacing `client/dist` assets served to operators.

The DB insert side already reduces `filepath` to `path.basename(...)`; the file write loop was missing the same treatment.

## Fix

Validate every `gcode_files` key before writing anything. A key that is not a bare filename (contains a path separator, or resolves outside `GCODE_DIR`) is rejected with `400`. A genuine export only ever contains bare filenames, so real backups are unaffected.

## Tests

Adds `server/tests/backup-restore.test.js`:
- traversal key (`../../pwned.js`) is rejected and nothing is written outside `GCODE_DIR`
- a bare `..` key is rejected
- a normal filename is written inside `GCODE_DIR`

Full suite: 24 suites / 381 tests passing under Node 22.

## Note on overlap

This touches the same `gcode_files` write loop that PR #8 rewrites. PR #8 does not change this loop, so the vulnerability is unaffected by it. If #8 merges first this will need a trivial rebase; the validation belongs before the same write regardless of the surrounding refactor.