### PR TITLE
chore(gcodes): harden upload filename handling and add upload limits

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,15 +47,16 @@ With the repo now public, printer manufacturers and community members may want t
 Covers: the four-function driver interface with exact return shapes and error contracts (`UPLOAD_CONFLICT`, never-throw `getStatus`, resolve-only-when-started `uploadAndPrint`), the `printer` row fields drivers may use, the canonical status table with what the poller/scheduler do on each transition, the no-double-credit rules for `FINISHED` (reconnect flapping, cold start, STOPPED vs ERROR disambiguation, synthesized FINISHED), the stateless vs persistent-connection patterns with named reference drivers, a six-step registration checklist (including every `Settings.jsx` touch point), a real-hardware test matrix, and dev-without-a-fleet tips.
 
 No code changes. `docs/README.md` gained an index row; `CONTRIBUTING.md`'s Printer Drivers section now links to the guide.
-## 2026-07-05 - G-code upload: strip path components from the stored filename
 
-The upload handler named the on-disk file `Date.now() + '_' + file.originalname`, where `file.originalname` comes from the client and multer does not strip path separators. A filename such as `../../../x.bgcode` therefore wrote outside `GCODE_DIR`. The timestamp prefix only cancelled one `..` segment, so an extra `../` still escaped.
+---
 
-The filename callback now runs `file.originalname` through `path.basename` before use, so the write always stays inside `GCODE_DIR`. Added a multer `limits` of 500 MB and a single file per request.
+## 2026-07-05 - G-code upload: harden filename handling and add upload limits
+
+The upload handler named the on-disk file `Date.now() + '_' + file.originalname`. The current stack routes multipart filenames through Busboy with `preservePath` unset (default `false`), which reduces a path-bearing filename to its basename before `file.originalname` is set, so the previous code was not writing outside `GCODE_DIR`. This adds `path.basename` in the filename callback as defense-in-depth, so the guarantee holds locally rather than relying on that transitive default, and adds multer `limits` (500 MB, one file per request) which the endpoint previously lacked.
 
 ### Changes
-- `server/routes/gcodes.js`: `path.basename(file.originalname)` in the multer filename callback; added `limits: { fileSize, files }`.
-- `server/tests/gcodes.test.js`: added a test that a traversal filename is stored inside `GCODE_DIR` and does not escape it.
+- `server/routes/gcodes.js`: `path.basename(file.originalname)` in the multer filename callback (defense-in-depth); added `limits: { fileSize: 500 MB, files: 1 }`.
+- `server/tests/gcodes.test.js`: assert the stored filename is always a basename, and that a second file in one request is rejected by the `files` limit.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,15 @@ With the repo now public, printer manufacturers and community members may want t
 Covers: the four-function driver interface with exact return shapes and error contracts (`UPLOAD_CONFLICT`, never-throw `getStatus`, resolve-only-when-started `uploadAndPrint`), the `printer` row fields drivers may use, the canonical status table with what the poller/scheduler do on each transition, the no-double-credit rules for `FINISHED` (reconnect flapping, cold start, STOPPED vs ERROR disambiguation, synthesized FINISHED), the stateless vs persistent-connection patterns with named reference drivers, a six-step registration checklist (including every `Settings.jsx` touch point), a real-hardware test matrix, and dev-without-a-fleet tips.
 
 No code changes. `docs/README.md` gained an index row; `CONTRIBUTING.md`'s Printer Drivers section now links to the guide.
+## 2026-07-05 - G-code upload: strip path components from the stored filename
+
+The upload handler named the on-disk file `Date.now() + '_' + file.originalname`, where `file.originalname` comes from the client and multer does not strip path separators. A filename such as `../../../x.bgcode` therefore wrote outside `GCODE_DIR`. The timestamp prefix only cancelled one `..` segment, so an extra `../` still escaped.
+
+The filename callback now runs `file.originalname` through `path.basename` before use, so the write always stays inside `GCODE_DIR`. Added a multer `limits` of 500 MB and a single file per request.
+
+### Changes
+- `server/routes/gcodes.js`: `path.basename(file.originalname)` in the multer filename callback; added `limits: { fileSize, files }`.
+- `server/tests/gcodes.test.js`: added a test that a traversal filename is stored inside `GCODE_DIR` and does not escape it.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -400,6 +400,8 @@ Upload a G-code file and create a DB record. `Content-Type: multipart/form-data`
 
 Returns `201` with created G-code record. Returns `409` if a G-code for this `(part_id, printer_model)` combination already exists.
 
+The uploaded filename is reduced to its basename before it is stored, so any path components in the client-supplied name are discarded. Maximum upload size is 500 MB, one file per request.
+
 ### `PUT /api/gcodes/:id`
 
 Update `est_print_secs` and/or `material_grams` for a G-code. Omitting a field leaves it unchanged; sending `null` or `""` clears it.

--- a/server/routes/gcodes.js
+++ b/server/routes/gcodes.js
@@ -8,8 +8,8 @@ const GCODE_DIR = path.join(__dirname, '..', 'gcode');
 
 const storage = multer.diskStorage({
   destination: GCODE_DIR,
-  // path.basename strips any directory components from the client-supplied name so a
-  // filename like "../../x" cannot write outside GCODE_DIR.
+  // Busboy already reduces multipart filenames to their basename (preservePath off), so
+  // this path.basename is defense-in-depth rather than relying on that transitive default.
   filename: (_req, file, cb) => cb(null, Date.now() + '_' + path.basename(file.originalname)),
 });
 const upload = multer({ storage, limits: { fileSize: 500 * 1024 * 1024, files: 1 } });

--- a/server/routes/gcodes.js
+++ b/server/routes/gcodes.js
@@ -8,9 +8,11 @@ const GCODE_DIR = path.join(__dirname, '..', 'gcode');
 
 const storage = multer.diskStorage({
   destination: GCODE_DIR,
-  filename: (_req, file, cb) => cb(null, Date.now() + '_' + file.originalname),
+  // path.basename strips any directory components from the client-supplied name so a
+  // filename like "../../x" cannot write outside GCODE_DIR.
+  filename: (_req, file, cb) => cb(null, Date.now() + '_' + path.basename(file.originalname)),
 });
-const upload = multer({ storage });
+const upload = multer({ storage, limits: { fileSize: 500 * 1024 * 1024, files: 1 } });
 
 function runUpload(req, res) {
   return new Promise((resolve, reject) => {

--- a/server/tests/gcodes.test.js
+++ b/server/tests/gcodes.test.js
@@ -189,6 +189,31 @@ describe('POST /api/gcodes/upload', () => {
     uploadedPath = res.body.filepath;
   });
 
+  test('sanitises a traversal filename so the upload stays inside GCODE_DIR', async () => {
+    // Dedicated model so the (part_id, printer_model) pair is unique among these tests.
+    db.prepare(`INSERT OR IGNORE INTO printer_models VALUES ('trav', 'Traversal', 'prusa')`).run();
+    const tmpFile = makeTempGcode('traversal_src.bgcode');
+
+    const res = await request(app)
+      .post('/api/gcodes/upload')
+      .attach('file', tmpFile, { filename: '../../../pwned.bgcode' })
+      .field('part_id', '1')
+      .field('parts_per_plate', '4')
+      .field('printer_model', 'trav');
+
+    fs.unlinkSync(tmpFile);
+
+    expect(res.status).toBe(201);
+    expect(res.body.filepath).not.toMatch(/[\\/]/);
+    expect(res.body.filepath).toMatch(/pwned\.bgcode$/);
+
+    const stored = path.join(GCODE_DIR, res.body.filepath);
+    expect(fs.existsSync(stored)).toBe(true);
+    expect(fs.existsSync(path.resolve(GCODE_DIR, '..', '..', '..', 'pwned.bgcode'))).toBe(false);
+
+    uploadedPath = stored;
+  });
+
   test('returns 400 when no file is attached', async () => {
     const res = await request(app)
       .post('/api/gcodes/upload')

--- a/server/tests/gcodes.test.js
+++ b/server/tests/gcodes.test.js
@@ -189,7 +189,9 @@ describe('POST /api/gcodes/upload', () => {
     uploadedPath = res.body.filepath;
   });
 
-  test('sanitises a traversal filename so the upload stays inside GCODE_DIR', async () => {
+  test('stored filename is always a basename (defense-in-depth)', async () => {
+    // Busboy already basenames multipart filenames (preservePath off), so a path-bearing
+    // name arrives here stripped; path.basename in the storage callback locks that in.
     // Dedicated model so the (part_id, printer_model) pair is unique among these tests.
     db.prepare(`INSERT OR IGNORE INTO printer_models VALUES ('trav', 'Traversal', 'prusa')`).run();
     const tmpFile = makeTempGcode('traversal_src.bgcode');
@@ -212,6 +214,24 @@ describe('POST /api/gcodes/upload', () => {
     expect(fs.existsSync(path.resolve(GCODE_DIR, '..', '..', '..', 'pwned.bgcode'))).toBe(false);
 
     uploadedPath = stored;
+  });
+
+  test('rejects more than one file per request (files limit)', async () => {
+    const a = makeTempGcode('multi_a.bgcode');
+    const b = makeTempGcode('multi_b.bgcode');
+
+    const res = await request(app)
+      .post('/api/gcodes/upload')
+      .attach('file', a)
+      .attach('file', b)
+      .field('part_id', '1')
+      .field('parts_per_plate', '4')
+      .field('printer_model', 'mk4s');
+
+    fs.unlinkSync(a);
+    fs.unlinkSync(b);
+
+    expect(res.status).toBe(400);
   });
 
   test('returns 400 when no file is attached', async () => {


### PR DESCRIPTION
## Context

This PR was originally filed as a path-traversal fix. That framing was wrong, and the correction is worth stating plainly.

The upload handler names the on-disk file `Date.now() + '_' + file.originalname`. `file.originalname` is client-supplied, but the current stack routes multipart filenames through Busboy with `preservePath` unset, and Busboy defaults that to `false`. In that mode a path-bearing filename (both `/` and `\`) is reduced to its basename before `file.originalname` is set. So the previous code was **not** writing outside `GCODE_DIR`, and there is no traversal exploit in this dependency stack.

## What this actually does

- **`path.basename(file.originalname)` in the storage callback** — kept as defense-in-depth so the containment guarantee holds locally rather than silently depending on Busboy's default (which a future bump or a `preservePath: true` elsewhere could change). It is a no-op on today's stack.
- **`limits: { fileSize: 500 MB, files: 1 }`** — the upload endpoint previously had no size or count cap. This is the substantive change (matches the cap already on the backup restore upload).

## Tests

`server/tests/gcodes.test.js`:
- stored filename is always a basename (defense-in-depth assertion; commented that Busboy also strips separators)
- a second file in one request is rejected by the `files` limit (proves the new limit)

Full suite: 23 suites / 380 tests passing under Node 22.