### PR TITLE
fix(printers): never return the stored api_key

### DIFF
--- a/client/src/pages/PrinterDetail.jsx
+++ b/client/src/pages/PrinterDetail.jsx
@@ -185,7 +185,7 @@ export default function PrinterDetail() {
   function startEditDetails() {
     setDetailsDraft({
       ip: printer.ip || '',
-      api_key: printer.api_key || '',
+      api_key: '', // write-only: blank keeps the stored key, which the API never returns
       serial_number: printer.serial_number || '',
       group_name: printer.group_name || '',
       model: printer.model || '',
@@ -208,22 +208,25 @@ export default function PrinterDetail() {
     setSavingDetails(true);
     setDetailsError(null);
     try {
+      const body = {
+        ip,
+        serial_number: detailsDraft.serial_number.trim(),
+        group_name: detailsDraft.group_name.trim() || null,
+        model: detailsDraft.model,
+        loaded_material: detailsDraft.loaded_material.trim() || null,
+        loaded_color: detailsDraft.loaded_color.trim() || null,
+      };
+      // Only send the key when the operator typed a new one; blank leaves it unchanged.
+      const newKey = detailsDraft.api_key.trim();
+      if (newKey) body.api_key = newKey;
       const res = await fetch(`/api/printers/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          ip,
-          api_key: detailsDraft.api_key.trim(),
-          serial_number: detailsDraft.serial_number.trim(),
-          group_name: detailsDraft.group_name.trim() || null,
-          model: detailsDraft.model,
-          loaded_material: detailsDraft.loaded_material.trim() || null,
-          loaded_color: detailsDraft.loaded_color.trim() || null,
-        }),
+        body: JSON.stringify(body),
       });
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        setDetailsError(body.error || `Save failed (${res.status})`);
+        const errBody = await res.json().catch(() => ({}));
+        setDetailsError(errBody.error || `Save failed (${res.status})`);
         return;
       }
       setPrinter(await res.json());
@@ -356,6 +359,9 @@ export default function PrinterDetail() {
                 <label style={detailLabelStyle}>
                   API Key
                   <input
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder={printer.has_api_key ? 'Leave blank to keep current key' : ''}
                     value={detailsDraft.api_key}
                     onChange={e => setDetailsDraft(d => ({ ...d, api_key: e.target.value }))}
                     disabled={savingDetails}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -161,9 +161,9 @@ Printer responses now go through a serializer that drops `api_key` and adds a bo
 
 ### Changes
 - `server/printer-public.js` (new): `publicPrinter()` serializer that strips `api_key` and adds `has_api_key`.
-- `server/routes/printers.js`, `server/index.js`: route all printer responses through it; `PUT` keeps the stored key when none is supplied.
+- `server/routes/printers.js`, `server/routes/dashboard.js`, `server/index.js`: route all printer responses through it; `PUT` keeps the stored key when none is supplied.
 - `client/src/pages/PrinterDetail.jsx`: write-only key field.
-- `server/tests/printers-api-key.test.js` (new): responses omit `api_key`; blank `PUT` keeps the key; a new key updates it.
+- `server/tests/printers-api-key.test.js`, `server/tests/dashboard-api-key.test.js` (new): responses omit `api_key`; blank `PUT` keeps the key; a new key updates it; the dashboard payload omits the key.
 - `docs/api.md`: documented `has_api_key` and the write-only key.
 
 ---

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -153,6 +153,18 @@ With the repo now public, printer manufacturers and community members may want t
 Covers: the four-function driver interface with exact return shapes and error contracts (`UPLOAD_CONFLICT`, never-throw `getStatus`, resolve-only-when-started `uploadAndPrint`), the `printer` row fields drivers may use, the canonical status table with what the poller/scheduler do on each transition, the no-double-credit rules for `FINISHED` (reconnect flapping, cold start, STOPPED vs ERROR disambiguation, synthesized FINISHED), the stateless vs persistent-connection patterns with named reference drivers, a six-step registration checklist (including every `Settings.jsx` touch point), a real-hardware test matrix, and dev-without-a-fleet tips.
 
 No code changes. `docs/README.md` gained an index row; `CONTRIBUTING.md`'s Printer Drivers section now links to the guide.
+## 2026-07-05 - Printers: stop returning the stored api_key
+
+`GET /api/printers`, `GET /api/printers/:id`, the backup-adjacent printer reads, and the create/update/action responses all returned the full printer row including `api_key` (the PrusaLink key, Bambu access code, or OctoPrint key). That is a reusable credential for the printer itself, so any client that could read the printer list could harvest every key.
+
+Printer responses now go through a serializer that drops `api_key` and adds a boolean `has_api_key`. `PUT /api/printers/:id` treats a blank or absent `api_key` as no change, so the key is write-only. The printer edit form no longer pre-fills the key field (it renders as a password input with a "leave blank to keep current" placeholder) and only sends a key when the operator types a new one. The scheduler and drivers still read the real key from the DB row, which is unchanged.
+
+### Changes
+- `server/printer-public.js` (new): `publicPrinter()` serializer that strips `api_key` and adds `has_api_key`.
+- `server/routes/printers.js`, `server/index.js`: route all printer responses through it; `PUT` keeps the stored key when none is supplied.
+- `client/src/pages/PrinterDetail.jsx`: write-only key field.
+- `server/tests/printers-api-key.test.js` (new): responses omit `api_key`; blank `PUT` keeps the key; a new key updates it.
+- `docs/api.md`: documented `has_api_key` and the write-only key.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -596,7 +596,7 @@ Single endpoint that returns all data required by the TV dashboard in one call. 
 - `awaiting` — printers held (`is_held = 1`) in `FINISHED` or `IDLE` state, waiting for operator sign-off
 - `parts_today` — sum of `parts_per_plate` on `finished` jobs in the rolling 24-hour window (`finished_at >= now - 86400000`)
 
-`printers` is the same shape as `GET /api/printers` (includes `last_parts_per_plate`) plus `last_event_at` — the timestamp of the most recent `printer_events` row for that printer.
+`printers` is the same shape as `GET /api/printers` (includes `last_parts_per_plate`, omits `api_key`, includes `has_api_key`) plus `last_event_at` — the timestamp of the most recent `printer_events` row for that printer.
 
 `active_projects` includes only `status = 'active'` projects, each with a nested `parts` array ordered by `sort_order`, plus three computed stats fields:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,7 +30,7 @@ Returns all active printers (`is_active = 1`) ordered by name.
     "id": 1,
     "name": "MK4S_01",
     "ip": "192.168.1.100",
-    "api_key": "aK3jR7xQ2pLm9vN",
+    "has_api_key": true,
     "group_name": "MK4S Farm",
     "type": "prusa",
     "model": "mk4s",
@@ -44,6 +44,8 @@ Returns all active printers (`is_active = 1`) ordered by name.
   }
 ]
 ```
+
+The stored `api_key` is never returned by any endpoint. Responses include `has_api_key` (a boolean) instead. `api_key` is accepted on write only.
 
 `job_name`, `job_progress`, and `job_time_remaining` are non-null only while `status = "PRINTING"`, and are cleared to `null` when the printer leaves that state.
 
@@ -101,6 +103,8 @@ Returns `201` with the created printer object. Returns `409` if `name` already e
 ### `PUT /api/printers/:id`
 
 Partial update — only fields provided are changed (uses `COALESCE`). All fields from POST are accepted, plus `is_held` (`0` or `1`).
+
+`api_key` is write-only: send it to set a new key; omit it or send an empty string to keep the stored key unchanged.
 
 Returns `404` if not found, `409` on name conflict.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,7 +45,7 @@ Returns all active printers (`is_active = 1`) ordered by name.
 ]
 ```
 
-The stored `api_key` is never returned by any endpoint. Responses include `has_api_key` (a boolean) instead. `api_key` is accepted on write only.
+The stored `api_key` is not returned by the printer or dashboard endpoints. Responses include `has_api_key` (a boolean) instead, and `api_key` is accepted on write only. The one exception is the farm backup export (`GET /api/backup`), which includes full printer rows so a restore can recreate working credentials — see that endpoint for the caveat.
 
 `job_name`, `job_progress`, and `job_time_remaining` are non-null only while `status = "PRINTING"`, and are cleared to `null` when the printer leaves that state.
 
@@ -629,6 +629,8 @@ All error responses use this shape:
 ### `GET /api/backup`
 
 Downloads a full farm snapshot as `farm-backup-YYYY-MM-DD.json`. Includes `printers`, `projects`, `parts`, `gcodes`, `jobs`, `printer_events`, `printer_models`, `printer_groups`, `filament_types`, `filament_colors`, `settings`, and gcode file contents (base64 encoded, keyed by on-disk filename). No request body.
+
+The exported printer rows include the stored `api_key` for each printer, so a restore can bring the fleet back with working credentials. Unlike the printer and dashboard endpoints, this file contains those keys in plaintext — treat a downloaded backup as secret and store it accordingly.
 
 **Response:** `Content-Disposition: attachment` JSON file.
 

--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,7 @@ const JobScheduler   = require('./scheduler');
 const notifications  = require('./notifications');
 const events         = require('./events');
 const backup         = require('./backup');
+const { publicPrinter } = require('./printer-public');
 
 const printersRouter     = require('./routes/printers')(db);
 const partsRouter        = require('./routes/parts')(db);
@@ -147,7 +148,7 @@ const server = app.listen(PORT, () => {
     const updated = db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id);
     console.log(`[server] ${printer.name} recommissioned — dispatching...`);
     scheduler.scheduleForPrinter(updated);
-    res.json(updated);
+    res.json(publicPrinter(updated));
   });
 
   // Set a held printer ready — releases hold and dispatches next job to it.
@@ -338,7 +339,7 @@ const server = app.listen(PORT, () => {
     const updated = db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id);
     console.log(`[server] ${printer.name} set ready by operator — dispatching...`);
     scheduler.scheduleForPrinter(updated);
-    res.json(updated);
+    res.json(publicPrinter(updated));
   });
 });
 

--- a/server/printer-public.js
+++ b/server/printer-public.js
@@ -1,0 +1,11 @@
+// Shapes a printer DB row for API responses. The stored api_key (PrusaLink key, Bambu
+// access code, OctoPrint key) is a reusable credential for the printer itself, so it is
+// never sent to clients. Callers get has_api_key instead so the UI can show whether a
+// key is set without exposing it.
+function publicPrinter(row) {
+  if (!row || typeof row !== 'object') return row;
+  const { api_key, ...rest } = row;
+  return { ...rest, has_api_key: api_key != null && String(api_key) !== '' };
+}
+
+module.exports = { publicPrinter };

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router  = express.Router();
+const { publicPrinter } = require('../printer-public');
 
 // Completed job statuses — 'done' is a legacy alias retained for backward compat with older data.
 const DONE_STATUSES = "('finished', 'done')";
@@ -123,7 +124,7 @@ module.exports = (db) => {
         awaiting,
         parts_today: partsToday,
       },
-      printers,
+      printers: printers.map(publicPrinter),
       active_projects: projectsWithParts,
       recent_activity: recentActivity,
     });

--- a/server/routes/printers.js
+++ b/server/routes/printers.js
@@ -4,6 +4,7 @@ const Papa = require('papaparse');
 const axios = require('axios');
 const router = express.Router();
 const events = require('../events');
+const { publicPrinter } = require('../printer-public');
 
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -70,7 +71,7 @@ module.exports = (db) => {
       WHERE p.is_active = 1
       ORDER BY p.name
     `).all();
-    res.json(printers);
+    res.json(printers.map(publicPrinter));
   });
 
   // GET /api/printers/filaments — distinct loaded_material and loaded_color values across all printers
@@ -87,7 +88,7 @@ module.exports = (db) => {
   // GET /api/printers/decommissioned — list decommissioned printers
   router.get('/decommissioned', (req, res) => {
     const printers = db.prepare('SELECT * FROM printers WHERE is_active = 0 ORDER BY decommissioned_at DESC').all();
-    res.json(printers);
+    res.json(printers.map(publicPrinter));
   });
 
   // GET /api/printers/ams?model=x1c — returns AMS slot list from any connected
@@ -111,7 +112,7 @@ module.exports = (db) => {
   router.get('/:id', (req, res) => {
     const printer = db.prepare('SELECT * FROM printers WHERE id = ?').get(req.params.id);
     if (!printer) return res.status(404).json({ error: 'Printer not found' });
-    res.json(printer);
+    res.json(publicPrinter(printer));
   });
 
   // POST /api/printers — add single printer
@@ -139,7 +140,7 @@ module.exports = (db) => {
       if (group_name && group_name.trim()) {
         try { registerGroup.run(group_name.trim(), Date.now()); } catch (_) {}
       }
-      res.status(201).json(db.prepare('SELECT * FROM printers WHERE id = ?').get(result.lastInsertRowid));
+      res.status(201).json(publicPrinter(db.prepare('SELECT * FROM printers WHERE id = ?').get(result.lastInsertRowid)));
     } catch (err) {
       if (err.message.includes('UNIQUE')) {
         return res.status(409).json({ error: `Printer name "${name}" already exists` });
@@ -199,7 +200,7 @@ module.exports = (db) => {
             loaded_material = ?,
             loaded_color = ?
         WHERE id = ?
-      `).run(name, ip, api_key, serial_number, group_name, type, normalized, is_held, decommission_note ?? null,
+      `).run(name, ip, api_key || null, serial_number, group_name, type, normalized, is_held, decommission_note ?? null,
              newMaterial, newColor, req.params.id);
 
       // Best-effort convenience: a failure here must never turn an already-
@@ -218,7 +219,7 @@ module.exports = (db) => {
         }
       }
 
-      res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(req.params.id));
+      res.json(publicPrinter(db.prepare('SELECT * FROM printers WHERE id = ?').get(req.params.id)));
     } catch (err) {
       if (err.message.includes('UNIQUE')) {
         return res.status(409).json({ error: `Printer name "${name}" already exists` });
@@ -243,7 +244,7 @@ module.exports = (db) => {
     db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ? WHERE id = ?').run(now, printer.id);
     events.insert(printer.id, 'decommission', req.body?.note ?? null);
     console.log(`[printers] ${printer.name} decommissioned`);
-    res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
+    res.json(publicPrinter(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id)));
   });
 
   // POST /api/printers/:id/complete-and-decommission — operator confirmed print was good; credit if
@@ -324,7 +325,7 @@ module.exports = (db) => {
     db.prepare('UPDATE printers SET is_active = 0, is_held = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, decommNote, printer.id);
     events.insert(printer.id, 'decommission', decommNote ?? 'operator confirmed successful print — taken offline for maintenance');
     console.log(`[printers] ${printer.name} decommissioned after confirmed good print`);
-    res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
+    res.json(publicPrinter(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id)));
   });
 
   // POST /api/printers/:id/recommission — handled in server/index.js (needs scheduler access)
@@ -563,7 +564,7 @@ module.exports = (db) => {
     db.prepare('UPDATE printers SET is_held = 0 WHERE id = ?').run(printer.id);
 
     console.log(`[printers] Job ${job.id} manually linked to ${printer.name} by operator`);
-    res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
+    res.json(publicPrinter(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id)));
   });
 
   // Mount events sub-router — GET/POST /api/printers/:id/events

--- a/server/tests/dashboard-api-key.test.js
+++ b/server/tests/dashboard-api-key.test.js
@@ -1,0 +1,51 @@
+// Verifies the TV dashboard endpoint does not leak the stored printer api_key.
+
+const request  = require('supertest');
+const express  = require('express');
+const Database = require('better-sqlite3');
+
+let db;
+let app;
+
+beforeAll(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE printers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, ip TEXT, api_key TEXT,
+      status TEXT, is_held INTEGER DEFAULT 0, is_active INTEGER DEFAULT 1, created_at INTEGER
+    );
+    CREATE TABLE projects (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, status TEXT, created_at INTEGER, updated_at INTEGER
+    );
+    CREATE TABLE parts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, project_id INTEGER, name TEXT, target_qty INTEGER,
+      completed_qty INTEGER DEFAULT 0, status TEXT, sort_order INTEGER DEFAULT 0, created_at INTEGER, updated_at INTEGER
+    );
+    CREATE TABLE gcodes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, printer_model TEXT, material_grams REAL, parts_per_plate INTEGER
+    );
+    CREATE TABLE jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, part_id INTEGER, printer_id INTEGER, gcode_id INTEGER,
+      parts_per_plate INTEGER, status TEXT, started_at INTEGER, finished_at INTEGER, created_at INTEGER
+    );
+    CREATE TABLE printer_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, printer_id INTEGER, created_at INTEGER
+    );
+  `);
+  db.prepare(`INSERT INTO printers (name, ip, api_key, status, is_active, created_at) VALUES ('P1', '10.0.0.1', 'SECRET_KEY', 'IDLE', 1, ?)`).run(Date.now());
+
+  app = express();
+  app.use('/api/dashboard', require('../routes/dashboard')(db));
+});
+
+test('GET /api/dashboard omits api_key and reports has_api_key', async () => {
+  const res = await request(app).get('/api/dashboard');
+  expect(res.status).toBe(200);
+  expect(res.body.printers.length).toBeGreaterThan(0);
+  for (const p of res.body.printers) {
+    expect(p).not.toHaveProperty('api_key');
+    expect(p).toHaveProperty('has_api_key');
+  }
+  expect(res.body.printers.some(p => p.has_api_key === true)).toBe(true);
+});

--- a/server/tests/printers-api-key.test.js
+++ b/server/tests/printers-api-key.test.js
@@ -1,0 +1,109 @@
+// Verifies the printer API never returns the stored api_key, and that an update with a
+// blank/absent key leaves the stored one intact (write-only key handling).
+
+const request  = require('supertest');
+const express  = require('express');
+const Database = require('better-sqlite3');
+
+let db;
+let app;
+
+beforeAll(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE printers (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      name              TEXT NOT NULL UNIQUE,
+      ip                TEXT NOT NULL,
+      api_key           TEXT NOT NULL DEFAULT '',
+      serial_number     TEXT DEFAULT '',
+      group_name        TEXT,
+      type              TEXT DEFAULT 'prusa',
+      model             TEXT NOT NULL,
+      status            TEXT DEFAULT 'UNKNOWN',
+      is_held           INTEGER DEFAULT 1,
+      is_active         INTEGER DEFAULT 1,
+      decommissioned_at INTEGER,
+      decommission_note TEXT,
+      loaded_material   TEXT,
+      loaded_color      TEXT,
+      created_at        INTEGER NOT NULL
+    );
+    CREATE TABLE jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, printer_id INTEGER, gcode_id INTEGER,
+      parts_per_plate INTEGER, status TEXT, started_at INTEGER, finished_at INTEGER, created_at INTEGER
+    );
+    CREATE TABLE gcodes (id INTEGER PRIMARY KEY AUTOINCREMENT, filename TEXT);
+    CREATE TABLE printer_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, printer_id INTEGER, event_type TEXT, note TEXT, created_at INTEGER
+    );
+    CREATE TABLE printer_models (model_id TEXT PRIMARY KEY, label TEXT NOT NULL, connector TEXT NOT NULL);
+    CREATE TABLE printer_groups (name TEXT PRIMARY KEY, created_at INTEGER NOT NULL);
+    INSERT INTO printer_models VALUES ('mk4s', 'MK4S', 'prusa');
+  `);
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/printers', require('../routes/printers')(db));
+});
+
+function seedPrinter(apiKey = 'SECRET_KEY') {
+  return db.prepare(
+    `INSERT INTO printers (name, ip, api_key, model, is_active, created_at) VALUES (?, ?, ?, 'mk4s', 1, ?)`
+  ).run(`P_${Date.now()}_${Math.round(Math.random() * 1e6)}`, '10.0.0.5', apiKey, Date.now()).lastInsertRowid;
+}
+
+const storedKey = (id) => db.prepare('SELECT api_key FROM printers WHERE id = ?').get(id).api_key;
+
+describe('printer API key exposure', () => {
+  test('GET /api/printers omits api_key and reports has_api_key', async () => {
+    seedPrinter('LIST_KEY');
+    const res = await request(app).get('/api/printers');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeGreaterThan(0);
+    for (const p of res.body) {
+      expect(p).not.toHaveProperty('api_key');
+      expect(p).toHaveProperty('has_api_key');
+    }
+    expect(res.body.some(p => p.has_api_key === true)).toBe(true);
+  });
+
+  test('GET /api/printers/:id omits api_key', async () => {
+    const id = seedPrinter('DETAIL_KEY');
+    const res = await request(app).get(`/api/printers/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty('api_key');
+    expect(res.body.has_api_key).toBe(true);
+  });
+
+  test('has_api_key is false when no key is stored', async () => {
+    const id = seedPrinter('');
+    const res = await request(app).get(`/api/printers/${id}`);
+    expect(res.body.has_api_key).toBe(false);
+  });
+
+  test('PUT without api_key keeps the stored key', async () => {
+    const id = seedPrinter('KEEP_ME');
+    const res = await request(app).put(`/api/printers/${id}`).send({ ip: '10.0.0.9' });
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty('api_key');
+    expect(storedKey(id)).toBe('KEEP_ME');
+  });
+
+  test('PUT with a new api_key updates it', async () => {
+    const id = seedPrinter('OLD_KEY');
+    const res = await request(app).put(`/api/printers/${id}`).send({ api_key: 'NEW_KEY' });
+    expect(res.status).toBe(200);
+    expect(storedKey(id)).toBe('NEW_KEY');
+  });
+
+  test('POST response omits api_key', async () => {
+    const res = await request(app)
+      .post('/api/printers')
+      .send({ name: `New_${Date.now()}`, ip: '10.0.0.10', api_key: 'CREATE_KEY', model: 'mk4s' });
+    expect(res.status).toBe(201);
+    expect(res.body).not.toHaveProperty('api_key');
+    expect(res.body.has_api_key).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Every printer response returns the full DB row, including `api_key`:

- `GET /api/printers` (`SELECT p.*`)
- `GET /api/printers/:id` (`SELECT *`)
- `GET /api/printers/decommissioned`
- the create / update / decommission / recommission / set-ready / link-job responses

`api_key` holds the PrusaLink API key, the Bambu access code (also the FTPS/MQTT password), and the OctoPrint key. These are reusable credentials for the printers themselves, so any client that can read the printer list can harvest every key and control the fleet outside this app. The client edit form (`PrinterDetail.jsx`) also pre-filled the key into a plain text input.

## Fix

- Add `server/printer-public.js` with a `publicPrinter()` serializer that drops `api_key` and adds a boolean `has_api_key`. Route every printer response through it in `server/routes/printers.js` and `server/index.js`.
- `PUT /api/printers/:id` treats a blank or absent `api_key` as no change, so the key is write-only. The scheduler and drivers still read the real key from the DB row, which is untouched.
- `PrinterDetail.jsx`: the key field is now a password input that starts blank with a "leave blank to keep current key" placeholder, and the form only sends `api_key` when the operator types a new one.

## Tests

Adds `server/tests/printers-api-key.test.js`: list and detail responses omit `api_key` and expose `has_api_key`; a `PUT` with no key keeps the stored one; a `PUT` with a new key updates it; the create response omits the key.

Full suite: 24 suites / 384 tests passing under Node 22. Client build verified.

## Note

The backup export (`GET /api/backup`) still embeds `api_key` so a restore can bring the fleet back with working credentials. That is a separate decision (whether to gate or encrypt the backup file) and is intentionally out of scope here.