### PR TITLE
Add build step to Quick Start in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ git clone https://github.com/joeltelling/print-farm-manager.git
 cd print-farm-manager
 npm install
 cd client && npm install && cd ..
+npm run build
 npm run dev
 ```
 


### PR DESCRIPTION
When running the [Quick Start (Development)](https://github.com/joeltelling/print-farm-manager/tree/main#quick-start-development) steps for the first time I ran into the following error:
```
  ERROR: client/dist/index.html not found.
  The React client has not been built yet.

  Run this once before starting the server:
    npm run build

  (See docs/installation.md for the full setup steps.)
```
Adding this step builds the client and enables running the print farm manager. 
