### PR TITLE
fix(reliability): crash resilience, graceful shutdown, persisted aler…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ---
 
+## 2026-07-07 — Reliability hardening (Tier 1): crash resilience, graceful shutdown, persisted alerts
+
+A pass over the server's failure modes. The theme: one bad thing should not take the whole farm down, a restart should not lose operator context, and a wedged process should be detectable.
+
+**1. Global handlers no longer crash-amplify.** `unhandledRejection` previously called `process.exit(1)` — so a single rejected promise (a flaky printer request, a driver hiccup) killed polling for all 50+ printers. It now logs and continues. `uncaughtException` still exits non-zero (the process is in an unknown state) but first runs a clean shutdown.
+
+**2. Graceful shutdown.** `SIGINT`/`SIGTERM` (and `uncaughtException`) now stop the poller, tear down all persistent printer connections, close the DB, and stop accepting HTTP connections before exiting — instead of dying mid-operation on every PM2 restart / `docker stop` / `update.bat`. A 5s failsafe forces exit if a connection lingers.
+
+**3. Operator notifications persist across restart.** Recoverable alerts (held printer with a missing G-code, stale-job auto-cancel, upload-failed-after-retries) were an in-memory array lost on restart — so after a crash the operator saw held printers with no explanation of why. They're now stored in a new `notifications` table. `notifications.init(db)` is called at startup; the store falls back to in-memory when no DB is wired (unit tests). The API response shape (`{ id, message, timestamp }`) is unchanged.
+
+**4. Persistent printer connections are torn down on removal.** Bambu/Elegoo drivers hold a per-printer MQTT/WebSocket client with a reconnect loop. `dropConnection` existed but was never called and never exported, so decommissioning or deleting a printer leaked its socket + reconnect timer forever. The driver registry now exposes `dropConnection(printer)` (called on delete and every decommission path) and `closeAllConnections()` (called on shutdown); each stateful driver exports `dropConnection` + a new `closeAll`.
+
+**5. Deeper health check.** `GET /api/health` now runs `SELECT 1` and reports the age of the last completed poll — returning `503` when the DB is unreachable or the poll loop has been stale for >60s, so PM2/Docker can restart a soft failure. New fields: `db`, `last_poll_at`, `poll_age_ms`.
+
+**6. Global JSON error handler.** An uncaught throw in any route now returns a clean `{ error }` response (matching the API error shape) instead of Express's default HTML 500. Covers the DB-heavy inline handlers (`set-ready`, `set-ready-batch`, `recommission`), which are synchronous, so Express routes their throws here.
+
+### Changes
+- `server/index.js`: resilient `unhandledRejection`/`uncaughtException` handlers; `SIGINT`/`SIGTERM` graceful shutdown (`shutdown()`); `notifications.init(db)`; deepened `/api/health`; global Express error handler; poller/scheduler/server hoisted so shutdown can reach them.
+- `server/notifications.js`: DB-backed via `init(db)`, in-memory fallback retained; `list()` aliases `created_at`→`timestamp` to preserve the API shape.
+- `server/db.js`: new additive `notifications` table (`CREATE TABLE IF NOT EXISTS`).
+- `server/poller.js`: tracks `lastPollAt` (epoch ms of last completed tick) for the health check.
+- `server/drivers/index.js`: memoizes loaded drivers; adds `dropConnection(printer)` and `closeAllConnections()`.
+- `server/drivers/bambu.js`, `elegoo-centauri.js`, `elegoo-centauri2.js`: export `dropConnection`; add `closeAll()`.
+- `server/routes/printers.js`: call `drivers.dropConnection(printer)` on delete and every decommission path.
+- `server/tests/notifications.test.js` (new): DB persistence incl. survives-restart round trip + in-memory fallback.
+- `server/tests/drivers-registry.test.js` (new): `getDriver` memoization/unknown-type; `dropConnection`/`closeAllConnections` dispatch.
+
+### Verified
+- Full suite: 26 suites, 397 tests pass (was 24/387).
+- Live: booted the server and confirmed `/api/health` reports `db: ok` + `last_poll_at` + `poll_age_ms`; wrote a notification from a separate process and read it back through `GET /api/notifications` (cross-process persistence). Graceful shutdown verified by code path — fires on real console Ctrl+C, PM2 `SIGINT`/`SIGTERM`, and `docker stop` (Git Bash can't inject a console Ctrl+C to a background process on Windows).
+
+### Follow-ups (not in this change)
+- `set-ready`'s multi-write credit sequence is not wrapped in a transaction, so a mid-sequence throw could leave a partial credit. Throws there are very unlikely (simple synchronous SQLite on validated ints), but wrapping the DB work in `db.transaction()` would make it atomic. Left out to avoid restructuring the delicate credit logic in a reliability-only pass.
+
+---
+
 ## 2026-07-06 - update.bat: discard package-lock.json drift before pulling
 
 `update.bat` runs `npm install`, which rewrites `package-lock.json` when the farm machine's npm version differs from the one that generated the lockfile. That local drift blocked `git pull` ("Your local changes ... would be overwritten by merge") the first time the lockfile changed upstream (the 2026-07-03 js-yaml bump). Hit on a real farm machine 2026-07-06.

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,9 +12,16 @@ All request bodies are JSON (`Content-Type: application/json`) unless noted othe
 
 ### `GET /api/health`
 
+Deep health check — probes the DB and the poll loop so a process that is up but wedged reports unhealthy (letting PM2/Docker restart it).
+
 ```json
-{ "status": "ok", "timestamp": 1774903214349 }
+{ "status": "ok", "db": "ok", "last_poll_at": 1774903200000, "poll_age_ms": 4200, "timestamp": 1774903214349 }
 ```
+
+- `200` with `status: "ok"` when the DB responds and the last completed poll is recent.
+- `503` with `status: "error"` and `db: "unreachable"` if the DB query fails.
+- `503` with `status: "degraded"` if the poll loop has been stale for more than 60s (`poll_age_ms > 60000`).
+- `last_poll_at` / `poll_age_ms` are `null` before the first poll completes (just after startup), which is not treated as unhealthy.
 
 ---
 
@@ -461,7 +468,7 @@ Called by the Projects UI when a project is activated or resumed.
 
 ## Notifications
 
-In-memory store of server-side alerts that require operator attention. Lost on server restart (errors will recur naturally on the next dispatch attempt if unresolved).
+Store of server-side alerts that require operator attention. **Persisted** in the `notifications` table, so a held printer's reason survives a crash/restart (previously an in-memory store lost on restart). Each alert is `{ id, message, timestamp }`.
 
 ### `GET /api/notifications`
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -167,6 +167,20 @@ CREATE TABLE IF NOT EXISTS printer_events (
 
 **Backfill migration:** on first server start after this table was introduced, any printer with `is_active = 0` and `decommissioned_at` set automatically receives a synthetic `decommission` event using the stored timestamp and note — idempotent across restarts.
 
+### notifications
+
+Recoverable operator alerts raised by the scheduler (held printer with a missing G-code, stale-job auto-cancel, upload-failed-after-retries). Persisted so a crash/restart doesn't leave held printers with no explanation of why.
+
+```sql
+CREATE TABLE IF NOT EXISTS notifications (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  message    TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+```
+
+Written by `server/notifications.js` (`add()`), which is DB-backed once `notifications.init(db)` runs at startup and falls back to an in-memory list otherwise (e.g. unit tests). The API (`GET /api/notifications`) aliases `created_at` to `timestamp` in its response for backward compatibility. Rows are removed on operator dismiss (`DELETE /api/notifications/:id`).
+
 ## Conventions
 
 - All IDs: `INTEGER PRIMARY KEY AUTOINCREMENT`

--- a/docs/driver-authoring.md
+++ b/docs/driver-authoring.md
@@ -47,7 +47,20 @@ deleteFile(printer, filename)
   → if exported, the scheduler calls it after a job finishes to clean the
     file off the printer's storage (see bambu.js). Fire-and-forget: errors
     are swallowed by the caller.
+
+dropConnection(printerId)   ← stateful drivers only
+  → close and forget this printer's persistent connection. The driver
+    registry calls it (via drivers.dropConnection(printer)) when a printer
+    is deleted or decommissioned, so a dead socket + reconnect loop doesn't
+    leak. Must be a safe no-op if no connection exists.
+
+closeAll()                  ← stateful drivers only
+  → close every live connection. Called by drivers.closeAllConnections()
+    on graceful shutdown so reconnect timers don't keep the process alive.
+    Typically: for (const id of [...connections.keys()]) dropConnection(id).
 ```
+
+If your driver holds persistent connections (the `bambu.js` / `elegoo-*.js` pattern), export both. Stateless HTTP drivers (`prusa.js` / `klipper.js` / `octoprint.js`) omit them — the registry treats their absence as a no-op.
 
 ### The `printer` row
 

--- a/docs/poller.md
+++ b/docs/poller.md
@@ -111,6 +111,10 @@ poller.start();   // begins polling immediately
 poller.stop();    // clears the interval (for clean shutdown / tests)
 ```
 
+## Liveness
+
+`poller.lastPollAt` holds the epoch-ms timestamp of the last completed tick (set on every path, including the no-printers and demo-mode early returns). `GET /api/health` reads it to detect a wedged poll loop — if the last tick is more than 60s old, health returns `503` so PM2/Docker can restart the process. `poller.stop()` is called by the server's graceful-shutdown handler (`SIGINT`/`SIGTERM`).
+
 ## Dependencies
 
 | Package | Purpose |

--- a/docs/server.md
+++ b/docs/server.md
@@ -12,7 +12,7 @@
 | `server/db.js` | SQLite connection, schema creation, directory setup |
 | `server/poller.js` | Printer status polling loop |
 | `server/scheduler.js` | Job dispatch engine — listens to poller events, dispatches prints |
-| `server/notifications.js` | In-memory alert store for recoverable server errors |
+| `server/notifications.js` | Operator alert store for recoverable server errors — DB-backed (persists across restart) via `init(db)`, with an in-memory fallback |
 | `server/routes/` | One file per resource (printers, projects, parts, gcodes, jobs, backup) |
 | `server/data/farm.db` | SQLite database file (auto-created, gitignored) |
 | `server/gcode/` | G-code file storage directory (auto-created, gitignored) |
@@ -26,6 +26,17 @@
 5. Inside the listen callback, `PrinterPoller` and `JobScheduler` are instantiated. `scheduler.start()` is called first (subscribes to poller events), then `poller.start()` fires the first poll tick and starts the 15-second interval.
 6. The startup sweep (`sweepIdlePrinters`) is deferred until the poller emits `pollComplete` after its first tick. This ensures dispatch works from live printer state rather than stale DB values from before the last shutdown — preventing accidental dispatch to a printer that started printing while the server was down.
 
+## Process Resilience & Shutdown
+
+`index.js` installs process-level handlers so a single failure doesn't take the whole farm down and a restart is clean:
+
+- **`unhandledRejection` → log and continue.** A rejected promise from a flaky printer request or driver hiccup is logged (`[WARN] unhandledRejection (continuing)`) and the process keeps running. (It used to `process.exit(1)`, which meant one rejection killed polling for all printers.)
+- **`uncaughtException` → clean shutdown, then exit 1.** The process is in an unknown state, so it runs `shutdown()` and exits non-zero for PM2/Docker to restart.
+- **`SIGINT` / `SIGTERM` → graceful shutdown.** `shutdown()` stops the poller, tears down every persistent printer connection (`drivers.closeAllConnections()`), closes the SQLite DB, and stops accepting new HTTP connections (`server.close()`), then exits 0. A 5-second failsafe forces exit if a connection lingers. This runs on every PM2 restart, `docker stop`, and console Ctrl+C.
+- **Global Express error handler.** Registered last (after the inline routes), it returns a clean `{ error }` JSON response for any uncaught route throw instead of Express's default HTML 500.
+
+`poller`, `scheduler`, and `server` are hoisted to module scope so `shutdown()` can reach them.
+
 ## Configuration
 
 | Variable | Default | Description |
@@ -37,7 +48,7 @@ No `.env` file is required. The only runtime configuration is `PORT`.
 ## Route Mounting
 
 ```
-GET    /api/health                  → health check (inline handler)
+GET    /api/health                  → deep health check: DB + poll liveness (inline handler)
 POST   /api/scheduler/dispatch      → scheduler.sweepIdlePrinters() (inline handler)
 GET    /api/notifications           → notifications.list() (inline handler)
 DELETE /api/notifications/:id       → notifications.dismiss() (inline handler)

--- a/server/db.js
+++ b/server/db.js
@@ -220,6 +220,18 @@ if (gcodeIdCol && gcodeIdCol.notnull === 1) {
   `);
 }
 
+// Persisted operator notifications — recoverable server alerts (held printer with
+// a missing G-code, stale-job auto-cancel, upload failed after retries). Persisting
+// these means a crash/restart no longer leaves the operator with held printers and
+// no explanation of why. Additive table — no migration framework (see CONTRIBUTING).
+db.exec(`
+  CREATE TABLE IF NOT EXISTS notifications (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    message    TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+  );
+`);
+
 // Backfill decommission events for printers that were decommissioned before the
 // printer_events table existed. Runs once per printer (checked via event absence).
 // Uses decommissioned_at as the event timestamp so the timeline is accurate.

--- a/server/drivers/bambu.js
+++ b/server/drivers/bambu.js
@@ -382,4 +382,10 @@ async function checkIfPrinting(printer) {
   return status === 'PRINTING' || status === 'PAUSED';
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, getAmsSlots, deleteFile };
+// Tear down every live MQTT connection — called on graceful shutdown so the
+// process exits cleanly instead of being held open by reconnect timers.
+function closeAll() {
+  for (const id of [...connections.keys()]) dropConnection(id);
+}
+
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, getAmsSlots, deleteFile, dropConnection, closeAll };

--- a/server/drivers/elegoo-centauri.js
+++ b/server/drivers/elegoo-centauri.js
@@ -227,4 +227,9 @@ async function checkIfPrinting(printer) {
   }
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting };
+// Tear down every live SDCP WebSocket connection — called on graceful shutdown.
+function closeAll() {
+  for (const id of [...connections.keys()]) dropConnection(id);
+}
+
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, dropConnection, closeAll };

--- a/server/drivers/elegoo-centauri2.js
+++ b/server/drivers/elegoo-centauri2.js
@@ -392,4 +392,9 @@ async function checkIfPrinting(printer) {
   }
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting };
+// Tear down every live MQTT connection — called on graceful shutdown.
+function closeAll() {
+  for (const id of [...connections.keys()]) dropConnection(id);
+}
+
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, dropConnection, closeAll };

--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -15,10 +15,36 @@ const LOADERS = {
   'octoprint':        () => require('./octoprint'),
 };
 
+// Memoize loaded driver modules so we can reach the ones that hold live
+// connections (Bambu/Elegoo) for teardown. require() already caches by path,
+// so this only tracks *which* drivers have been loaded this process.
+const instances = {};
+
 function getDriver(type) {
+  if (instances[type]) return instances[type];
   const load = LOADERS[type];
   if (!load) throw new Error(`No driver registered for printer type: "${type}"`);
-  return load();
+  instances[type] = load();
+  return instances[type];
 }
 
-module.exports = { getDriver };
+// Drop a single printer's persistent connection (if its driver keeps one and is
+// loaded). Safe no-op for stateless drivers (Prusa/Klipper/OctoPrint) and for
+// drivers never loaded this process. Called when a printer is deleted or
+// decommissioned so its socket + reconnect loop don't live on forever.
+function dropConnection(printer) {
+  const drv = instances[printer.type];
+  try { drv?.dropConnection?.(printer.id); } catch (_) {}
+}
+
+// Close every live connection across all loaded drivers — called on graceful
+// shutdown so reconnect timers don't keep the process alive.
+function closeAllConnections() {
+  for (const [type, drv] of Object.entries(instances)) {
+    try { drv.closeAll?.(); } catch (err) {
+      console.error(`[drivers] closeAll failed for "${type}": ${err.message}`);
+    }
+  }
+}
+
+module.exports = { getDriver, dropConnection, closeAllConnections };

--- a/server/index.js
+++ b/server/index.js
@@ -1,19 +1,9 @@
-// Catch unhandled errors before anything else so they're always logged,
-// even if Node exits before stdout is flushed (common on Windows).
-process.on('uncaughtException', (err) => {
-  process.stderr.write(`[FATAL] uncaughtException: ${err.stack || err}\n`);
-  process.exit(1);
-});
-process.on('unhandledRejection', (reason) => {
-  process.stderr.write(`[FATAL] unhandledRejection: ${reason?.stack || reason}\n`);
-  process.exit(1);
-});
-
 const express = require('express');
 const path    = require('path');
 const fs      = require('fs');
 
 const db             = require('./db');
+const drivers        = require('./drivers');
 const PrinterPoller  = require('./poller');
 const JobScheduler   = require('./scheduler');
 const notifications  = require('./notifications');
@@ -30,6 +20,52 @@ const settingsRouter     = require('./routes/settings')(db);
 const modelsRouter       = require('./routes/models')(db);
 const filamentsRouter    = require('./routes/filaments')(db);
 const printerJobsRouter  = require('./routes/printer-jobs')(db);
+
+// ── Process resilience & graceful shutdown ───────────────────────────────────
+// Persist operator notifications to the DB so a crash/restart doesn't leave held
+// printers with no explanation of why.
+notifications.init(db);
+
+let poller       = null;
+let scheduler    = null;
+let server       = null;
+let shuttingDown = false;
+
+function shutdown(reason, exitCode) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[server] Shutting down (${reason})...`);
+  try { poller?.stop(); } catch (_) {}
+  try { drivers.closeAllConnections(); } catch (_) {}
+  const finish = () => {
+    try { db.close(); } catch (_) {}
+    process.exit(exitCode);
+  };
+  if (server) {
+    server.close(finish);
+    setTimeout(finish, 5000).unref(); // force-exit if a connection lingers
+  } else {
+    finish();
+  }
+}
+
+process.on('SIGINT',  () => shutdown('SIGINT', 0));
+process.on('SIGTERM', () => shutdown('SIGTERM', 0));
+
+// A single rejected promise — a flaky printer request, a driver hiccup — must not
+// take the whole farm down. Log and keep running. (Previously: process.exit(1),
+// which meant one unhandled rejection killed polling for all 50+ printers.)
+process.on('unhandledRejection', (reason) => {
+  process.stderr.write(`[WARN] unhandledRejection (continuing): ${reason?.stack || reason}\n`);
+});
+
+// An uncaught exception leaves the process in an unknown state: log, shut down
+// cleanly (stop poller, drop printer connections, close DB), then exit non-zero
+// so PM2/Docker restarts us.
+process.on('uncaughtException', (err) => {
+  process.stderr.write(`[FATAL] uncaughtException: ${err.stack || err}\n`);
+  shutdown('uncaughtException', 1);
+});
 
 const app  = express();
 const PORT = process.env.PORT || 3000;
@@ -48,9 +84,30 @@ app.use('/api/settings',        settingsRouter);
 app.use('/api/models',          modelsRouter);
 app.use('/api/filaments',       filamentsRouter);
 
-// Health check
+// Health check — actually probes the DB and the poller so a process that is up
+// but wedged (DB locked, poll loop dead) reports unhealthy and PM2/Docker can
+// restart it. Returns 503 when a real dependency is down.
 app.get('/api/health', (req, res) => {
-  res.json({ status: 'ok', timestamp: Date.now() });
+  const now = Date.now();
+  try {
+    db.prepare('SELECT 1').get();
+  } catch (err) {
+    return res.status(503).json({ status: 'error', db: 'unreachable', error: err.message, timestamp: now });
+  }
+  const lastPollAt = poller?.lastPollAt ?? null;
+  const pollAgeMs  = lastPollAt == null ? null : now - lastPollAt;
+  // The poller ticks every 15s; treat >60s since the last completed tick as stale.
+  // Before the first tick completes (lastPollAt null) we don't fail — the server
+  // has only just started.
+  const pollStale = lastPollAt != null && pollAgeMs > 60000;
+  const status    = pollStale ? 'degraded' : 'ok';
+  res.status(pollStale ? 503 : 200).json({
+    status,
+    db: 'ok',
+    last_poll_at: lastPollAt,
+    poll_age_ms: pollAgeMs,
+    timestamp: now,
+  });
 });
 
 // Server notifications — surfaced in the Settings UI
@@ -82,11 +139,11 @@ app.get(/^(?!\/api).*/, (_req, res) => {
 });
 
 // Start server
-const server = app.listen(PORT, () => {
+server = app.listen(PORT, () => {
   console.log(`[server] Express running on http://localhost:${PORT}`);
 
-  const poller    = new PrinterPoller(db);
-  const scheduler = new JobScheduler(db, poller);
+  poller    = new PrinterPoller(db);
+  scheduler = new JobScheduler(db, poller);
 
   // Mount projects router here so it has access to the scheduler for complete/reactivate
   app.use('/api/projects', require('./routes/projects')(db, scheduler));
@@ -336,6 +393,17 @@ const server = app.listen(PORT, () => {
     scheduler.scheduleForPrinter(updated);
     res.json(updated);
   });
+
+  // Global JSON error handler — registered last (after the inline routes above)
+  // so any uncaught throw in any route returns a clean {error} response matching
+  // the API error shape instead of Express's default HTML page. The DB-heavy
+  // inline handlers (set-ready, set-ready-batch, recommission) are synchronous,
+  // so Express routes their throws here rather than crashing the process.
+  app.use((err, _req, res, _next) => {
+    console.error('[server] Unhandled route error:', err);
+    if (res.headersSent) return;
+    res.status(500).json({ error: 'Internal server error' });
+  });
 });
 
-module.exports = { app, server };
+module.exports = { app, get server() { return server; } };

--- a/server/notifications.js
+++ b/server/notifications.js
@@ -1,26 +1,51 @@
-// In-memory notification store — survives as long as the server process is running.
-// Notifications are lost on restart, which is fine: actionable errors will recur
-// naturally on the next dispatch attempt if the underlying issue hasn't been fixed.
+// Operator notification store for recoverable server alerts (held printer with a
+// missing G-code, stale-job auto-cancel, upload failed after retries).
+//
+// Backed by the `notifications` table so alerts survive a crash/restart — a held
+// printer's *reason* is no longer lost when the process dies. Call init(db) once
+// at startup. Until then (or in unit tests that don't wire a DB) it falls back to
+// an in-memory list so add/list/dismiss keep working.
 
+let _db = null;
 let _nextId = 1;
-const _store = [];
+const _mem = [];
+
+function init(db) {
+  _db = db;
+}
 
 function add(message) {
-  const note = { id: _nextId++, message, timestamp: Date.now() };
-  _store.push(note);
+  const timestamp = Date.now();
   console.warn(`[notifications] ${message}`);
+  if (_db) {
+    const info = _db
+      .prepare('INSERT INTO notifications (message, created_at) VALUES (?, ?)')
+      .run(message, timestamp);
+    return { id: Number(info.lastInsertRowid), message, timestamp };
+  }
+  const note = { id: _nextId++, message, timestamp };
+  _mem.push(note);
   return note;
 }
 
 function list() {
-  return [..._store].reverse(); // newest first
+  if (_db) {
+    // `timestamp` alias preserves the API response shape (see docs/api.md).
+    return _db
+      .prepare('SELECT id, message, created_at AS timestamp FROM notifications ORDER BY created_at DESC, id DESC')
+      .all();
+  }
+  return [..._mem].reverse(); // newest first
 }
 
 function dismiss(id) {
-  const idx = _store.findIndex(n => n.id === id);
+  if (_db) {
+    return _db.prepare('DELETE FROM notifications WHERE id = ?').run(id).changes > 0;
+  }
+  const idx = _mem.findIndex(n => n.id === id);
   if (idx === -1) return false;
-  _store.splice(idx, 1);
+  _mem.splice(idx, 1);
   return true;
 }
 
-module.exports = { add, list, dismiss };
+module.exports = { init, add, list, dismiss };

--- a/server/poller.js
+++ b/server/poller.js
@@ -8,6 +8,7 @@ class PrinterPoller extends EventEmitter {
     super();
     this.db = db;
     this.timer = null;
+    this.lastPollAt = null; // epoch ms of the last completed tick — surfaced by /api/health
   }
 
   start() {
@@ -25,6 +26,7 @@ class PrinterPoller extends EventEmitter {
 
   async _tick() {
     if (process.env.DEMO_MODE === 'true') {
+      this.lastPollAt = Date.now();
       this.emit('pollComplete');
       return;
     }
@@ -33,7 +35,10 @@ class PrinterPoller extends EventEmitter {
       .prepare('SELECT * FROM printers WHERE is_active = 1')
       .all();
 
-    if (printers.length === 0) return;
+    if (printers.length === 0) {
+      this.lastPollAt = Date.now();
+      return;
+    }
 
     const results = await Promise.allSettled(
       printers.map((printer) => this._pollPrinter(printer))
@@ -45,6 +50,7 @@ class PrinterPoller extends EventEmitter {
       }
     });
 
+    this.lastPollAt = Date.now();
     this.emit('pollComplete');
   }
 

--- a/server/routes/printers.js
+++ b/server/routes/printers.js
@@ -4,6 +4,7 @@ const Papa = require('papaparse');
 const axios = require('axios');
 const router = express.Router();
 const events = require('../events');
+const drivers = require('../drivers');
 
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -224,6 +225,7 @@ module.exports = (db) => {
   router.delete('/:id', (req, res) => {
     const printer = db.prepare('SELECT * FROM printers WHERE id = ?').get(req.params.id);
     if (!printer) return res.status(404).json({ error: 'Printer not found' });
+    drivers.dropConnection(printer); // tear down any persistent MQTT/WS connection
     db.prepare('DELETE FROM printers WHERE id = ?').run(req.params.id);
     res.json({ success: true });
   });
@@ -234,6 +236,7 @@ module.exports = (db) => {
     if (!printer) return res.status(404).json({ error: 'Printer not found' });
     const now = Date.now();
     db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ? WHERE id = ?').run(now, printer.id);
+    drivers.dropConnection(printer); // tear down any persistent MQTT/WS connection
     events.insert(printer.id, 'decommission', req.body?.note ?? null);
     console.log(`[printers] ${printer.name} decommissioned`);
     res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
@@ -315,6 +318,7 @@ module.exports = (db) => {
 
     const decommNote = req.body?.note ?? null;
     db.prepare('UPDATE printers SET is_active = 0, is_held = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, decommNote, printer.id);
+    drivers.dropConnection(printer); // tear down any persistent MQTT/WS connection
     events.insert(printer.id, 'decommission', decommNote ?? 'operator confirmed successful print — taken offline for maintenance');
     console.log(`[printers] ${printer.name} decommissioned after confirmed good print`);
     res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
@@ -370,6 +374,7 @@ module.exports = (db) => {
       const now = Date.now();
       const noJobNote = req.body?.note ?? null;
       db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, noJobNote, printer.id);
+      drivers.dropConnection(printer); // tear down any persistent MQTT/WS connection
       events.insert(printer.id, 'job_failed', noJobNote ?? 'No tracked job — printer decommissioned for investigation');
       console.log(`[printers] ${printer.name} decommissioned (no tracked job to mark failed)`);
       return res.json({ success: true, job_id: null });
@@ -405,6 +410,7 @@ module.exports = (db) => {
     // The operator must explicitly recommission it when the machine is confirmed safe.
     const failNote = req.body?.note ?? null;
     db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, failNote, printer.id);
+    drivers.dropConnection(printer); // tear down any persistent MQTT/WS connection
 
     const failedPart = db.prepare('SELECT name FROM parts WHERE id = ?').get(job.part_id);
     const eventNote = failNote

--- a/server/tests/drivers-registry.test.js
+++ b/server/tests/drivers-registry.test.js
@@ -1,0 +1,49 @@
+// Verifies the driver registry (server/drivers/index.js): getDriver memoization
+// and unknown-type error, plus the connection-teardown dispatch added for Tier 1
+// (dropConnection on printer removal, closeAllConnections on shutdown).
+
+// Mock the Bambu driver so we can observe teardown dispatch without real MQTT.
+jest.mock('../drivers/bambu', () => ({
+  getStatus: jest.fn(),
+  uploadAndPrint: jest.fn(),
+  cancelJob: jest.fn(),
+  checkIfPrinting: jest.fn(),
+  dropConnection: jest.fn(),
+  closeAll: jest.fn(),
+}));
+
+const bambu = require('../drivers/bambu');
+const drivers = require('../drivers');
+
+describe('driver registry', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('getDriver returns the driver module and memoizes it', () => {
+    const a = drivers.getDriver('bambu');
+    const b = drivers.getDriver('bambu');
+    expect(a).toBe(bambu);
+    expect(b).toBe(a);
+  });
+
+  test('getDriver throws for an unknown type', () => {
+    expect(() => drivers.getDriver('nope')).toThrow(/No driver registered/);
+  });
+
+  test('dropConnection dispatches to the loaded driver with the printer id', () => {
+    drivers.getDriver('bambu'); // ensure loaded
+    drivers.dropConnection({ id: 42, type: 'bambu' });
+    expect(bambu.dropConnection).toHaveBeenCalledWith(42);
+  });
+
+  test('dropConnection is a safe no-op for a stateless / never-loaded driver', () => {
+    // 'prusa' has no dropConnection export and isn't loaded here — must not throw.
+    expect(() => drivers.dropConnection({ id: 1, type: 'prusa' })).not.toThrow();
+    expect(bambu.dropConnection).not.toHaveBeenCalled();
+  });
+
+  test('closeAllConnections calls closeAll on every loaded driver', () => {
+    drivers.getDriver('bambu');
+    drivers.closeAllConnections();
+    expect(bambu.closeAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/tests/notifications.test.js
+++ b/server/tests/notifications.test.js
@@ -1,0 +1,84 @@
+// Verifies the DB-backed notification store: alerts persist to the `notifications`
+// table so a crash/restart doesn't leave held printers with no explanation, and the
+// API response shape ({ id, message, timestamp }) is preserved. Also covers the
+// in-memory fallback used before init(db) / in tests that don't wire a DB.
+
+const Database = require('better-sqlite3');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+const notifications = require('../notifications');
+
+const SCHEMA = `CREATE TABLE IF NOT EXISTS notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  message TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);`;
+
+function memDb() {
+  const db = new Database(':memory:');
+  db.exec(SCHEMA);
+  return db;
+}
+
+function tmpFile() {
+  return path.join(os.tmpdir(), `pfm-notif-${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e6)}.db`);
+}
+
+describe('notifications (DB-backed)', () => {
+  let db;
+  beforeEach(() => { db = memDb(); notifications.init(db); });
+  afterEach(() => { notifications.init(null); db.close(); });
+
+  test('add persists a row and returns { id, message, timestamp }', () => {
+    const note = notifications.add('held: missing gcode');
+    expect(note).toMatchObject({ message: 'held: missing gcode' });
+    expect(typeof note.id).toBe('number');
+    expect(typeof note.timestamp).toBe('number');
+    const row = db.prepare('SELECT * FROM notifications WHERE id = ?').get(note.id);
+    expect(row.message).toBe('held: missing gcode');
+  });
+
+  test('list returns newest first with a timestamp field (API shape)', () => {
+    notifications.add('alert one');
+    notifications.add('alert two');
+    const list = notifications.list();
+    expect(list.map(n => n.message)).toEqual(['alert two', 'alert one']);
+    expect(list[0]).toHaveProperty('timestamp');
+    expect(list[0]).not.toHaveProperty('created_at');
+  });
+
+  test('dismiss removes a notification; unknown id returns false', () => {
+    const note = notifications.add('dismiss me');
+    expect(notifications.dismiss(note.id)).toBe(true);
+    expect(notifications.list()).toHaveLength(0);
+    expect(notifications.dismiss(99999)).toBe(false);
+  });
+});
+
+test('notifications survive a restart — a fresh DB connection still sees them', () => {
+  const file = tmpFile();
+  const db1 = new Database(file);
+  db1.exec(SCHEMA);
+  notifications.init(db1);
+  notifications.add('printer held: re-upload MK4S gcode');
+  db1.close(); // process "dies"
+
+  // New process boots against the same DB file.
+  const db2 = new Database(file);
+  notifications.init(db2);
+  expect(notifications.list().map(n => n.message)).toContain('printer held: re-upload MK4S gcode');
+  db2.close();
+  notifications.init(null);
+  fs.unlinkSync(file);
+});
+
+test('falls back to in-memory when no DB is initialized', () => {
+  notifications.init(null);
+  const note = notifications.add('mem only');
+  expect(note.message).toBe('mem only');
+  expect(notifications.list()[0].message).toBe('mem only');
+  expect(notifications.dismiss(note.id)).toBe(true);
+  expect(notifications.list()).toHaveLength(0);
+});


### PR DESCRIPTION
…ts (Tier 1)

Harden the server's failure modes so one fault can't take the whole farm down, a restart doesn't lose operator context, and a wedged process is detectable.

- unhandledRejection now logs and continues instead of process.exit(1) (a single rejected driver/network promise no longer kills polling for all printers). uncaughtException runs a clean shutdown, then exits 1.
- SIGINT/SIGTERM graceful shutdown: stop poller, tear down persistent printer connections, close DB, stop the HTTP server, then exit. 5s failsafe. Fires on PM2 restart / docker stop / console Ctrl+C.
- Operator notifications persist in a new `notifications` table so a held printer's reason survives a crash/restart. notifications.init(db) at startup; in-memory fallback retained. API shape unchanged.
- Bambu/Elegoo drivers export dropConnection + closeAll; registry adds drivers.dropConnection(printer) (called on delete + every decommission path) and closeAllConnections() (shutdown). Fixes a per-printer MQTT/WS socket + reconnect-loop leak on printer removal.
- Deep /api/health: runs SELECT 1 and reports last-poll age; 503 when the DB is unreachable or the poll loop is stale >60s. New fields: db, last_poll_at, poll_age_ms (poller.lastPollAt).
- Global Express JSON error handler: uncaught route throws return {error} instead of an HTML 500 (covers the synchronous set-ready handlers).

Tests: +notifications.test.js (DB persistence incl. survives-restart), +drivers-registry.test.js (memoization, teardown dispatch). Full suite 26 suites / 397 tests pass. Docs updated (CHANGELOG, server, database, poller, api, driver-authoring).