### PR TITLE
fix(reliability): crash resilience, graceful shutdown, persisted alerts (Tier 1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,39 @@ Also verified: hot reload actually round-trips through the bind mount (`docker c
 - `README.md`: added a "Prefer Docker instead of a local Node.js install?" subsection under Quick Start (Development), alongside (not replacing) the native steps; documented running the test suite via `docker compose exec print-farm-manager-dev npm test`.
 - `CONTRIBUTING.md`: same Docker cross-reference and test-running note added to "Getting Set Up", which had its own independent copy of the native setup steps this PR hadn't touched yet.
 - `docs/installation.md`, `docs/README.md`: cross-referenced the new `dev` service from the existing dev-mode note, the top-level Quick Start, and the file-structure index.
+## 2026-07-07 — Reliability hardening (Tier 1): crash resilience, graceful shutdown, persisted alerts
+
+A pass over the server's failure modes. The theme: one bad thing should not take the whole farm down, a restart should not lose operator context, and a wedged process should be detectable.
+
+**1. Global handlers no longer crash-amplify.** `unhandledRejection` previously called `process.exit(1)` — so a single rejected promise (a flaky printer request, a driver hiccup) killed polling for all 50+ printers. It now logs and continues. `uncaughtException` still exits non-zero (the process is in an unknown state) but first runs a clean shutdown.
+
+**2. Graceful shutdown.** `SIGINT`/`SIGTERM` (and `uncaughtException`) now stop the poller, tear down all persistent printer connections, close the DB, and stop accepting HTTP connections before exiting — instead of dying mid-operation on every PM2 restart / `docker stop` / `update.bat`. A 5s failsafe forces exit if a connection lingers.
+
+**3. Operator notifications persist across restart.** Recoverable alerts (held printer with a missing G-code, stale-job auto-cancel, upload-failed-after-retries) were an in-memory array lost on restart — so after a crash the operator saw held printers with no explanation of why. They're now stored in a new `notifications` table. `notifications.init(db)` is called at startup; the store falls back to in-memory when no DB is wired (unit tests). The API response shape (`{ id, message, timestamp }`) is unchanged.
+
+**4. Persistent printer connections are torn down on removal.** Bambu/Elegoo drivers hold a per-printer MQTT/WebSocket client with a reconnect loop. `dropConnection` existed but was never called and never exported, so decommissioning or deleting a printer leaked its socket + reconnect timer forever. The driver registry now exposes `dropConnection(printer)` (called on delete and every decommission path) and `closeAllConnections()` (called on shutdown); each stateful driver exports `dropConnection` + a new `closeAll`.
+
+**5. Deeper health check.** `GET /api/health` now runs `SELECT 1` and reports the age of the last completed poll — returning `503` when the DB is unreachable or the poll loop has been stale for >60s, so PM2/Docker can restart a soft failure. New fields: `db`, `last_poll_at`, `poll_age_ms`.
+
+**6. Global JSON error handler.** An uncaught throw in any route now returns a clean `{ error }` response (matching the API error shape) instead of Express's default HTML 500. Covers the DB-heavy inline handlers (`set-ready`, `set-ready-batch`, `recommission`), which are synchronous, so Express routes their throws here.
+
+### Changes
+- `server/index.js`: resilient `unhandledRejection`/`uncaughtException` handlers; `SIGINT`/`SIGTERM` graceful shutdown (`shutdown()`); `notifications.init(db)`; deepened `/api/health`; global Express error handler; poller/scheduler/server hoisted so shutdown can reach them.
+- `server/notifications.js`: DB-backed via `init(db)`, in-memory fallback retained; `list()` aliases `created_at`→`timestamp` to preserve the API shape.
+- `server/db.js`: new additive `notifications` table (`CREATE TABLE IF NOT EXISTS`).
+- `server/poller.js`: tracks `lastPollAt` (epoch ms of last completed tick) for the health check.
+- `server/drivers/index.js`: memoizes loaded drivers; adds `dropConnection(printer)` and `closeAllConnections()`.
+- `server/drivers/bambu.js`, `elegoo-centauri.js`, `elegoo-centauri2.js`: export `dropConnection`; add `closeAll()`.
+- `server/routes/printers.js`: call `drivers.dropConnection(printer)` on delete and every decommission path.
+- `server/tests/notifications.test.js` (new): DB persistence incl. survives-restart round trip + in-memory fallback.
+- `server/tests/drivers-registry.test.js` (new): `getDriver` memoization/unknown-type; `dropConnection`/`closeAllConnections` dispatch.
+
+### Verified
+- Full suite: 26 suites, 397 tests pass (was 24/387).
+- Live: booted the server and confirmed `/api/health` reports `db: ok` + `last_poll_at` + `poll_age_ms`; wrote a notification from a separate process and read it back through `GET /api/notifications` (cross-process persistence). Graceful shutdown verified by code path — fires on real console Ctrl+C, PM2 `SIGINT`/`SIGTERM`, and `docker stop` (Git Bash can't inject a console Ctrl+C to a background process on Windows).
+
+### Follow-ups (not in this change)
+- `set-ready`'s multi-write credit sequence is not wrapped in a transaction, so a mid-sequence throw could leave a partial credit. Throws there are very unlikely (simple synchronous SQLite on validated ints), but wrapping the DB work in `db.transaction()` would make it atomic. Left out to avoid restructuring the delicate credit logic in a reliability-only pass.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,21 @@ A pass over the server's failure modes. The theme: one bad thing should not take
 ### Follow-ups (not in this change)
 - `set-ready`'s multi-write credit sequence is not wrapped in a transaction, so a mid-sequence throw could leave a partial credit. Throws there are very unlikely (simple synchronous SQLite on validated ints), but wrapping the DB work in `db.transaction()` would make it atomic. Left out to avoid restructuring the delicate credit logic in a reliability-only pass.
 
+### Follow-up (adversarial review) — 2026-07-07
+
+A multi-agent adversarial review of the above diff (9 reviewers + per-finding refutation) confirmed **no part-count risk and no crash bugs** — the credit path is untouched. It surfaced several P3 issues, now fixed:
+
+- **[C1] elegoo-centauri connect-window leak.** `getConnection` registered the client into the `connections` map *after* `await client.Connect()`. A `DELETE`/decommission during that await found nothing to drop, so the resolved client (with `AutoReconnect`) reconnected forever to a printer that no longer existed — the exact leak this change set out to kill. Also a latent double-connect race. Fixed by registering before the await and removing the client on connect failure (matching the bambu/CC2 pattern).
+- **[C3] crash handlers lost the `[FATAL]` path for load-time throws.** Moving `uncaughtException`/`unhandledRejection` below the `require`/`init` block meant a throw during module load bypassed the guaranteed synchronous `stderr` logging. Moved both back above the requires; runtime state (`poller`/`server`/`shuttingDown`) is declared first and `shutdown()` guards every step, so an early crash still exits cleanly.
+- **[C2] stale driver connections after restore.** `POST /api/backup/restore` wipes and reinserts `printers` but never dropped cached MQTT/WS clients, so a restore that changed a printer's IP left the poller using the stale client until restart. Now calls `drivers.closeAllConnections()` after the restore commits; the next poll rebuilds from restored config.
+- **[M1] hourly backup vs `db.close()` on shutdown.** The new graceful `db.close()` could close the connection mid-`db.backup()`. Added `backup.stop()` (clears the interval), called first in `shutdown()`.
+- **[M2] notifications and backup.** Documented that the now-persistent `notifications` table is intentionally excluded from farm backup/restore (live operational state; re-raised by the scheduler if still unresolved).
+- **Tests.** Added `printers-dropconnection.test.js` — spies `drivers.dropConnection` and asserts every fleet-exit route (delete + all four decommission paths) calls it with the printer row (the headline fix was previously executed but unasserted). Fixed a tautological memoization assertion in `drivers-registry.test.js` and wrapped the notifications survives-restart temp file in `try/finally` (incl. WAL sidecars).
+
+Verified clean via the full suite (**27 suites, 402 tests**) and a live boot (`/api/health` green on the restructured `index.js`).
+
+Remaining coverage gaps the review flagged (no live defect; regression-protection only): direct tests for `shutdown()` ordering, the `/api/health` branches, and the global error handler would each need `index.js` to export those units (or an `if (require.main === module)` listen guard for full-server integration tests) — deferred.
+
 ---
 
 ## 2026-07-06 - update.bat: discard package-lock.json drift before pulling

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,6 +82,15 @@ Remaining coverage gaps the review flagged (no live defect; regression-protectio
 
 Tests: `server/tests/backup.test.js` (new) covers `whenIdle()` waiting for an in-flight backup; `server/tests/printers-dropconnection.test.js` gains cases for PUT changing `ip`/`api_key`/`serial_number` (drops) vs a non-connection field (no drop). Full suite: **28 suites, 408 tests**.
 
+### Follow-up (PR review, round 3) — 2026-07-08
+
+Rebased the branch onto the latest `main` (Docker dev-workflow, PR #24) to clear a merge conflict, then two more review fixes:
+
+- **[P2] Track the in-flight backup correctly across overlapping runs.** The round-2 fix kept a single `_active` promise that each `runBackup` overwrote — so if a slow run overlapped the next hourly tick and the newer run finished first, `whenIdle()` could report idle while the older `db.backup()` was still copying, reintroducing the mid-copy-close race. `runBackup` now **skips** if a backup is already in flight (backups take seconds; this also avoids two concurrent `db.backup()` on one connection), so `_active` always refers to the single running backup.
+- **[P2] Disable Centauri autoreconnect before dropping the socket.** `elegoo-centauri.js` `dropConnection()` closed the WebSocket but left `AutoReconnect` set, and `SDCPPrinterWS`'s close handler re-`Connect`s whenever `AutoReconnect !== false` — so a dropped Centauri connection (delete/decommission/restore/shutdown) revived itself and the reconnect loop outlived the printer. Now sets `client.AutoReconnect = false` (the exact value the lib treats as off — a number sets a retry interval) before `Disconnect()`.
+
+Tests: `backup.test.js` gains a no-overlap case; `elegoo-driver.test.js` gains `dropConnection`/`closeAll` cases asserting `AutoReconnect` is set to `false`, `Disconnect` is called, and the pool entry is removed (next poll reconstructs the client). Full suite: **28 suites, 412 tests**.
+
 ---
 
 ## 2026-07-06 - update.bat: discard package-lock.json drift before pulling

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,14 @@ Verified clean via the full suite (**27 suites, 402 tests**) and a live boot (`/
 
 Remaining coverage gaps the review flagged (no live defect; regression-protection only): direct tests for `shutdown()` ordering, the `/api/health` branches, and the global error handler would each need `index.js` to export those units (or an `if (require.main === module)` listen guard for full-server integration tests) — deferred.
 
+### Follow-up (PR review, round 2) — 2026-07-08
+
+- **[P2] Wait for an in-flight backup before closing the DB.** `backup.stop()` only cleared the future interval — a `SIGTERM` landing during the startup or hourly `db.backup()` still let `shutdown()` reach `db.close()`/`process.exit()` mid-copy, risking a corrupt snapshot. `server/backup.js` now tracks the active backup promise and exposes `whenIdle()`; `shutdown()` awaits it before `db.close()`, with an absolute 5s force-exit failsafe so a hung backup or connection can't wedge shutdown.
+- **[P2] Drop the cached driver connection when a printer's connection settings change.** `PUT /api/printers/:id` can change `ip`/`type`/`api_key`/`serial_number`, but Bambu/Elegoo drivers cache a client per `printer.id` and `getConnection()` returned the stale one — so after an operator fixed an IP/access-code/serial/connector the poller kept talking to the old host until restart. The PUT handler now calls `drivers.dropConnection(oldRow)` whenever a connection-defining field changes (using the pre-update row so a type change tears the connection down under its previous driver); the next poll reconnects with the new settings.
+- **[P3] Docs index.** `docs/README.md` still called `notifications.js` an "In-memory operator alert store" — updated to reflect the persisted `notifications` table.
+
+Tests: `server/tests/backup.test.js` (new) covers `whenIdle()` waiting for an in-flight backup; `server/tests/printers-dropconnection.test.js` gains cases for PUT changing `ip`/`api_key`/`serial_number` (drops) vs a non-connection field (no drop). Full suite: **28 suites, 408 tests**.
+
 ---
 
 ## 2026-07-06 - update.bat: discard package-lock.json drift before pulling

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ print-farm-manager/
 │   ├── poller.js         # Printer polling loop (EventEmitter)
 │   ├── scheduler.js      # Job dispatch engine (EventEmitter)
 │   ├── events.js         # Printer event log helper — insert(printerId, type, note)
-│   ├── notifications.js  # In-memory operator alert store
+│   ├── notifications.js  # Operator alert store — persisted in the notifications table (survives restart)
 │   └── routes/
 │       ├── printers.js   # CRUD + CSV import + decommission/recommission
 │       ├── events.js     # GET/POST /api/printers/:id/events

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,9 +12,16 @@ All request bodies are JSON (`Content-Type: application/json`) unless noted othe
 
 ### `GET /api/health`
 
+Deep health check — probes the DB and the poll loop so a process that is up but wedged reports unhealthy (letting PM2/Docker restart it).
+
 ```json
-{ "status": "ok", "timestamp": 1774903214349 }
+{ "status": "ok", "db": "ok", "last_poll_at": 1774903200000, "poll_age_ms": 4200, "timestamp": 1774903214349 }
 ```
+
+- `200` with `status: "ok"` when the DB responds and the last completed poll is recent.
+- `503` with `status: "error"` and `db: "unreachable"` if the DB query fails.
+- `503` with `status: "degraded"` if the poll loop has been stale for more than 60s (`poll_age_ms > 60000`).
+- `last_poll_at` / `poll_age_ms` are `null` before the first poll completes (just after startup), which is not treated as unhealthy.
 
 ---
 
@@ -461,7 +468,7 @@ Called by the Projects UI when a project is activated or resumed.
 
 ## Notifications
 
-In-memory store of server-side alerts that require operator attention. Lost on server restart (errors will recur naturally on the next dispatch attempt if unresolved).
+Store of server-side alerts that require operator attention. **Persisted** in the `notifications` table, so a held printer's reason survives a crash/restart (previously an in-memory store lost on restart). Each alert is `{ id, message, timestamp }`.
 
 ### `GET /api/notifications`
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -167,6 +167,20 @@ CREATE TABLE IF NOT EXISTS printer_events (
 
 **Backfill migration:** on first server start after this table was introduced, any printer with `is_active = 0` and `decommissioned_at` set automatically receives a synthetic `decommission` event using the stored timestamp and note — idempotent across restarts.
 
+### notifications
+
+Recoverable operator alerts raised by the scheduler (held printer with a missing G-code, stale-job auto-cancel, upload-failed-after-retries). Persisted so a crash/restart doesn't leave held printers with no explanation of why.
+
+```sql
+CREATE TABLE IF NOT EXISTS notifications (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  message    TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+```
+
+Written by `server/notifications.js` (`add()`), which is DB-backed once `notifications.init(db)` runs at startup and falls back to an in-memory list otherwise (e.g. unit tests). The API (`GET /api/notifications`) aliases `created_at` to `timestamp` in its response for backward compatibility. Rows are removed on operator dismiss (`DELETE /api/notifications/:id`).
+
 ## Conventions
 
 - All IDs: `INTEGER PRIMARY KEY AUTOINCREMENT`

--- a/docs/database.md
+++ b/docs/database.md
@@ -181,6 +181,8 @@ CREATE TABLE IF NOT EXISTS notifications (
 
 Written by `server/notifications.js` (`add()`), which is DB-backed once `notifications.init(db)` runs at startup and falls back to an in-memory list otherwise (e.g. unit tests). The API (`GET /api/notifications`) aliases `created_at` to `timestamp` in its response for backward compatibility. Rows are removed on operator dismiss (`DELETE /api/notifications/:id`).
 
+**Intentionally excluded from farm backup/restore.** Notifications are live operational state — each one points at a specific held printer and G-code and is only actionable while that condition persists. `GET /api/backup` does not export the table and restore does not touch it, so importing a backup neither ships stale alerts nor clears the ones on the running instance. If the underlying condition is still unresolved after a restart, the scheduler re-raises the alert on the next dispatch attempt.
+
 ## Conventions
 
 - All IDs: `INTEGER PRIMARY KEY AUTOINCREMENT`

--- a/docs/driver-authoring.md
+++ b/docs/driver-authoring.md
@@ -47,7 +47,20 @@ deleteFile(printer, filename)
   → if exported, the scheduler calls it after a job finishes to clean the
     file off the printer's storage (see bambu.js). Fire-and-forget: errors
     are swallowed by the caller.
+
+dropConnection(printerId)   ← stateful drivers only
+  → close and forget this printer's persistent connection. The driver
+    registry calls it (via drivers.dropConnection(printer)) when a printer
+    is deleted or decommissioned, so a dead socket + reconnect loop doesn't
+    leak. Must be a safe no-op if no connection exists.
+
+closeAll()                  ← stateful drivers only
+  → close every live connection. Called by drivers.closeAllConnections()
+    on graceful shutdown so reconnect timers don't keep the process alive.
+    Typically: for (const id of [...connections.keys()]) dropConnection(id).
 ```
+
+If your driver holds persistent connections (the `bambu.js` / `elegoo-*.js` pattern), export both. Stateless HTTP drivers (`prusa.js` / `klipper.js` / `octoprint.js`) omit them — the registry treats their absence as a no-op.
 
 ### The `printer` row
 

--- a/docs/poller.md
+++ b/docs/poller.md
@@ -111,6 +111,10 @@ poller.start();   // begins polling immediately
 poller.stop();    // clears the interval (for clean shutdown / tests)
 ```
 
+## Liveness
+
+`poller.lastPollAt` holds the epoch-ms timestamp of the last completed tick (set on every path, including the no-printers and demo-mode early returns). `GET /api/health` reads it to detect a wedged poll loop — if the last tick is more than 60s old, health returns `503` so PM2/Docker can restart the process. `poller.stop()` is called by the server's graceful-shutdown handler (`SIGINT`/`SIGTERM`).
+
 ## Dependencies
 
 | Package | Purpose |

--- a/docs/server.md
+++ b/docs/server.md
@@ -12,7 +12,7 @@
 | `server/db.js` | SQLite connection, schema creation, directory setup |
 | `server/poller.js` | Printer status polling loop |
 | `server/scheduler.js` | Job dispatch engine — listens to poller events, dispatches prints |
-| `server/notifications.js` | In-memory alert store for recoverable server errors |
+| `server/notifications.js` | Operator alert store for recoverable server errors — DB-backed (persists across restart) via `init(db)`, with an in-memory fallback |
 | `server/routes/` | One file per resource (printers, projects, parts, gcodes, jobs, backup) |
 | `server/data/farm.db` | SQLite database file (auto-created, gitignored) |
 | `server/gcode/` | G-code file storage directory (auto-created, gitignored) |
@@ -26,6 +26,17 @@
 5. Inside the listen callback, `PrinterPoller` and `JobScheduler` are instantiated. `scheduler.start()` is called first (subscribes to poller events), then `poller.start()` fires the first poll tick and starts the 15-second interval.
 6. The startup sweep (`sweepIdlePrinters`) is deferred until the poller emits `pollComplete` after its first tick. This ensures dispatch works from live printer state rather than stale DB values from before the last shutdown — preventing accidental dispatch to a printer that started printing while the server was down.
 
+## Process Resilience & Shutdown
+
+`index.js` installs process-level handlers so a single failure doesn't take the whole farm down and a restart is clean:
+
+- **`unhandledRejection` → log and continue.** A rejected promise from a flaky printer request or driver hiccup is logged (`[WARN] unhandledRejection (continuing)`) and the process keeps running. (It used to `process.exit(1)`, which meant one rejection killed polling for all printers.)
+- **`uncaughtException` → clean shutdown, then exit 1.** The process is in an unknown state, so it runs `shutdown()` and exits non-zero for PM2/Docker to restart.
+- **`SIGINT` / `SIGTERM` → graceful shutdown.** `shutdown()` stops the poller, tears down every persistent printer connection (`drivers.closeAllConnections()`), closes the SQLite DB, and stops accepting new HTTP connections (`server.close()`), then exits 0. A 5-second failsafe forces exit if a connection lingers. This runs on every PM2 restart, `docker stop`, and console Ctrl+C.
+- **Global Express error handler.** Registered last (after the inline routes), it returns a clean `{ error }` JSON response for any uncaught route throw instead of Express's default HTML 500.
+
+`poller`, `scheduler`, and `server` are hoisted to module scope so `shutdown()` can reach them.
+
 ## Configuration
 
 | Variable | Default | Description |
@@ -37,7 +48,7 @@ No `.env` file is required. The only runtime configuration is `PORT`.
 ## Route Mounting
 
 ```
-GET    /api/health                  → health check (inline handler)
+GET    /api/health                  → deep health check: DB + poll liveness (inline handler)
 POST   /api/scheduler/dispatch      → scheduler.sweepIdlePrinters() (inline handler)
 GET    /api/notifications           → notifications.list() (inline handler)
 DELETE /api/notifications/:id       → notifications.dismiss() (inline handler)

--- a/server/backup.js
+++ b/server/backup.js
@@ -18,9 +18,17 @@ function timestamp() {
 let _active = null; // promise of the in-flight backup, or null when idle
 
 async function runBackup(db) {
+  // Never run two backups at once: a slow run overlapping the next hourly tick
+  // would overwrite `_active`, so whenIdle() could see it cleared (newer run done)
+  // while an older `db.backup()` is still copying — the exact mid-copy-close race
+  // this guards against. It also avoids two concurrent db.backup() on one
+  // connection. Backups take seconds, so skipping a tick here is harmless.
+  if (_active) {
+    console.warn('[backup] Previous backup still running — skipping this run');
+    return;
+  }
   // Track the in-flight run so graceful shutdown can wait for it before closing
-  // the DB — closing the connection (or exiting) mid-`db.backup()` corrupts the
-  // snapshot. `_doBackup` swallows its own errors, so `_active` never rejects.
+  // the DB. `_doBackup` swallows its own errors, so `_active` never rejects.
   const p = _doBackup(db);
   _active = p;
   try { await p; } finally { if (_active === p) _active = null; }

--- a/server/backup.js
+++ b/server/backup.js
@@ -45,10 +45,21 @@ function pruneOldBackups() {
   }
 }
 
+let _timer = null;
+
 function start(db) {
   // Run immediately on startup, then every hour
   runBackup(db);
-  setInterval(() => runBackup(db), INTERVAL_MS);
+  _timer = setInterval(() => runBackup(db), INTERVAL_MS);
 }
 
-module.exports = { start, runBackup };
+// Stop the hourly timer — called on graceful shutdown before db.close() so a
+// scheduled backup can't start against a connection that's about to close.
+function stop() {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+}
+
+module.exports = { start, runBackup, stop };

--- a/server/backup.js
+++ b/server/backup.js
@@ -15,7 +15,18 @@ function timestamp() {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}-${pad(d.getHours())}`;
 }
 
+let _active = null; // promise of the in-flight backup, or null when idle
+
 async function runBackup(db) {
+  // Track the in-flight run so graceful shutdown can wait for it before closing
+  // the DB — closing the connection (or exiting) mid-`db.backup()` corrupts the
+  // snapshot. `_doBackup` swallows its own errors, so `_active` never rejects.
+  const p = _doBackup(db);
+  _active = p;
+  try { await p; } finally { if (_active === p) _active = null; }
+}
+
+async function _doBackup(db) {
   if (!fs.existsSync(BACKUP_DIR)) fs.mkdirSync(BACKUP_DIR, { recursive: true });
 
   const dest = path.join(BACKUP_DIR, `farm-${timestamp()}.db`);
@@ -62,4 +73,13 @@ function stop() {
   }
 }
 
-module.exports = { start, runBackup, stop };
+// Resolves once no backup is in flight (immediately if already idle). Graceful
+// shutdown awaits this after stop() and before db.close(), so it never closes the
+// connection or exits mid-`db.backup()`.
+async function whenIdle() {
+  while (_active) {
+    try { await _active; } catch (_) { /* _doBackup never rejects; belt-and-braces */ }
+  }
+}
+
+module.exports = { start, runBackup, stop, whenIdle };

--- a/server/db.js
+++ b/server/db.js
@@ -220,6 +220,18 @@ if (gcodeIdCol && gcodeIdCol.notnull === 1) {
   `);
 }
 
+// Persisted operator notifications — recoverable server alerts (held printer with
+// a missing G-code, stale-job auto-cancel, upload failed after retries). Persisting
+// these means a crash/restart no longer leaves the operator with held printers and
+// no explanation of why. Additive table — no migration framework (see CONTRIBUTING).
+db.exec(`
+  CREATE TABLE IF NOT EXISTS notifications (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    message    TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+  );
+`);
+
 // Backfill decommission events for printers that were decommissioned before the
 // printer_events table existed. Runs once per printer (checked via event absence).
 // Uses decommissioned_at as the event timestamp so the timeline is accurate.

--- a/server/drivers/bambu.js
+++ b/server/drivers/bambu.js
@@ -382,4 +382,10 @@ async function checkIfPrinting(printer) {
   return status === 'PRINTING' || status === 'PAUSED';
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, getAmsSlots, deleteFile };
+// Tear down every live MQTT connection — called on graceful shutdown so the
+// process exits cleanly instead of being held open by reconnect timers.
+function closeAll() {
+  for (const id of [...connections.keys()]) dropConnection(id);
+}
+
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, getAmsSlots, deleteFile, dropConnection, closeAll };

--- a/server/drivers/elegoo-centauri.js
+++ b/server/drivers/elegoo-centauri.js
@@ -227,4 +227,9 @@ async function checkIfPrinting(printer) {
   }
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting };
+// Tear down every live SDCP WebSocket connection — called on graceful shutdown.
+function closeAll() {
+  for (const id of [...connections.keys()]) dropConnection(id);
+}
+
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, dropConnection, closeAll };

--- a/server/drivers/elegoo-centauri.js
+++ b/server/drivers/elegoo-centauri.js
@@ -42,8 +42,19 @@ async function getConnection(printer) {
     if (process.env.DEBUG_ELEGOO) console.warn(`[elegoo] ${printer.name} error:`, err?.message || err);
   });
 
-  await client.Connect(printer.ip);
+  // Register BEFORE awaiting Connect. If a concurrent dropConnection (printer
+  // deleted/decommissioned mid-connect) ran while we awaited, it would find
+  // nothing in the map and no-op, leaving this client — with AutoReconnect — to
+  // reconnect forever to a printer that no longer exists. Registering first also
+  // prevents a concurrent getConnection from opening a second client. On connect
+  // failure, remove it so a later poll re-creates it.
   connections.set(printer.id, client);
+  try {
+    await client.Connect(printer.ip);
+  } catch (err) {
+    dropConnection(printer.id);
+    throw err;
+  }
   console.log(`[elegoo] Connected to ${printer.name} (${printer.ip})`);
   return client;
 }

--- a/server/drivers/elegoo-centauri.js
+++ b/server/drivers/elegoo-centauri.js
@@ -59,10 +59,17 @@ async function getConnection(printer) {
   return client;
 }
 
-// Remove a connection from the pool (called when a printer is unreachable)
+// Remove a connection from the pool (called when a printer is unreachable, or is
+// deleted/decommissioned, or on graceful shutdown).
 function dropConnection(printerId) {
   const client = connections.get(printerId);
   if (client) {
+    // Turn OFF autoreconnect before disconnecting. SDCPPrinterWS's close handler
+    // re-Connects whenever AutoReconnect !== false, so without this the socket we're
+    // dropping revives itself and the reconnect loop outlives the printer. Only the
+    // exact value `false` disables it — a number sets a retry interval (see
+    // sdcp/SDCPPrinterWS.js set AutoReconnect / the close handler).
+    try { client.AutoReconnect = false; } catch (_) {}
     try { client.Disconnect?.(); } catch (_) {}
     connections.delete(printerId);
   }

--- a/server/drivers/elegoo-centauri2.js
+++ b/server/drivers/elegoo-centauri2.js
@@ -392,4 +392,9 @@ async function checkIfPrinting(printer) {
   }
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting };
+// Tear down every live MQTT connection — called on graceful shutdown.
+function closeAll() {
+  for (const id of [...connections.keys()]) dropConnection(id);
+}
+
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, dropConnection, closeAll };

--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -15,10 +15,36 @@ const LOADERS = {
   'octoprint':        () => require('./octoprint'),
 };
 
+// Memoize loaded driver modules so we can reach the ones that hold live
+// connections (Bambu/Elegoo) for teardown. require() already caches by path,
+// so this only tracks *which* drivers have been loaded this process.
+const instances = {};
+
 function getDriver(type) {
+  if (instances[type]) return instances[type];
   const load = LOADERS[type];
   if (!load) throw new Error(`No driver registered for printer type: "${type}"`);
-  return load();
+  instances[type] = load();
+  return instances[type];
 }
 
-module.exports = { getDriver };
+// Drop a single printer's persistent connection (if its driver keeps one and is
+// loaded). Safe no-op for stateless drivers (Prusa/Klipper/OctoPrint) and for
+// drivers never loaded this process. Called when a printer is deleted or
+// decommissioned so its socket + reconnect loop don't live on forever.
+function dropConnection(printer) {
+  const drv = instances[printer.type];
+  try { drv?.dropConnection?.(printer.id); } catch (_) {}
+}
+
+// Close every live connection across all loaded drivers — called on graceful
+// shutdown so reconnect timers don't keep the process alive.
+function closeAllConnections() {
+  for (const [type, drv] of Object.entries(instances)) {
+    try { drv.closeAll?.(); } catch (err) {
+      console.error(`[drivers] closeAll failed for "${type}": ${err.message}`);
+    }
+  }
+}
+
+module.exports = { getDriver, dropConnection, closeAllConnections };

--- a/server/index.js
+++ b/server/index.js
@@ -1,19 +1,9 @@
-// Catch unhandled errors before anything else so they're always logged,
-// even if Node exits before stdout is flushed (common on Windows).
-process.on('uncaughtException', (err) => {
-  process.stderr.write(`[FATAL] uncaughtException: ${err.stack || err}\n`);
-  process.exit(1);
-});
-process.on('unhandledRejection', (reason) => {
-  process.stderr.write(`[FATAL] unhandledRejection: ${reason?.stack || reason}\n`);
-  process.exit(1);
-});
-
 const express = require('express');
 const path    = require('path');
 const fs      = require('fs');
 
 const db             = require('./db');
+const drivers        = require('./drivers');
 const PrinterPoller  = require('./poller');
 const JobScheduler   = require('./scheduler');
 const notifications  = require('./notifications');
@@ -30,6 +20,52 @@ const settingsRouter     = require('./routes/settings')(db);
 const modelsRouter       = require('./routes/models')(db);
 const filamentsRouter    = require('./routes/filaments')(db);
 const printerJobsRouter  = require('./routes/printer-jobs')(db);
+
+// ── Process resilience & graceful shutdown ───────────────────────────────────
+// Persist operator notifications to the DB so a crash/restart doesn't leave held
+// printers with no explanation of why.
+notifications.init(db);
+
+let poller       = null;
+let scheduler    = null;
+let server       = null;
+let shuttingDown = false;
+
+function shutdown(reason, exitCode) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[server] Shutting down (${reason})...`);
+  try { poller?.stop(); } catch (_) {}
+  try { drivers.closeAllConnections(); } catch (_) {}
+  const finish = () => {
+    try { db.close(); } catch (_) {}
+    process.exit(exitCode);
+  };
+  if (server) {
+    server.close(finish);
+    setTimeout(finish, 5000).unref(); // force-exit if a connection lingers
+  } else {
+    finish();
+  }
+}
+
+process.on('SIGINT',  () => shutdown('SIGINT', 0));
+process.on('SIGTERM', () => shutdown('SIGTERM', 0));
+
+// A single rejected promise — a flaky printer request, a driver hiccup — must not
+// take the whole farm down. Log and keep running. (Previously: process.exit(1),
+// which meant one unhandled rejection killed polling for all 50+ printers.)
+process.on('unhandledRejection', (reason) => {
+  process.stderr.write(`[WARN] unhandledRejection (continuing): ${reason?.stack || reason}\n`);
+});
+
+// An uncaught exception leaves the process in an unknown state: log, shut down
+// cleanly (stop poller, drop printer connections, close DB), then exit non-zero
+// so PM2/Docker restarts us.
+process.on('uncaughtException', (err) => {
+  process.stderr.write(`[FATAL] uncaughtException: ${err.stack || err}\n`);
+  shutdown('uncaughtException', 1);
+});
 
 const app  = express();
 const PORT = process.env.PORT || 3000;
@@ -48,9 +84,30 @@ app.use('/api/settings',        settingsRouter);
 app.use('/api/models',          modelsRouter);
 app.use('/api/filaments',       filamentsRouter);
 
-// Health check
+// Health check — actually probes the DB and the poller so a process that is up
+// but wedged (DB locked, poll loop dead) reports unhealthy and PM2/Docker can
+// restart it. Returns 503 when a real dependency is down.
 app.get('/api/health', (req, res) => {
-  res.json({ status: 'ok', timestamp: Date.now() });
+  const now = Date.now();
+  try {
+    db.prepare('SELECT 1').get();
+  } catch (err) {
+    return res.status(503).json({ status: 'error', db: 'unreachable', error: err.message, timestamp: now });
+  }
+  const lastPollAt = poller?.lastPollAt ?? null;
+  const pollAgeMs  = lastPollAt == null ? null : now - lastPollAt;
+  // The poller ticks every 15s; treat >60s since the last completed tick as stale.
+  // Before the first tick completes (lastPollAt null) we don't fail — the server
+  // has only just started.
+  const pollStale = lastPollAt != null && pollAgeMs > 60000;
+  const status    = pollStale ? 'degraded' : 'ok';
+  res.status(pollStale ? 503 : 200).json({
+    status,
+    db: 'ok',
+    last_poll_at: lastPollAt,
+    poll_age_ms: pollAgeMs,
+    timestamp: now,
+  });
 });
 
 // Server notifications — surfaced in the Settings UI
@@ -82,11 +139,11 @@ app.get(/^(?!\/api).*/, (_req, res) => {
 });
 
 // Start server
-const server = app.listen(PORT, () => {
+server = app.listen(PORT, () => {
   console.log(`[server] Express running on http://localhost:${PORT}`);
 
-  const poller    = new PrinterPoller(db);
-  const scheduler = new JobScheduler(db, poller);
+  poller    = new PrinterPoller(db);
+  scheduler = new JobScheduler(db, poller);
 
   // Mount projects router here so it has access to the scheduler for complete/reactivate
   app.use('/api/projects', require('./routes/projects')(db, scheduler));
@@ -336,6 +393,17 @@ const server = app.listen(PORT, () => {
     scheduler.scheduleForPrinter(updated);
     res.json(updated);
   });
+
+  // Global JSON error handler — registered last (after the inline routes above)
+  // so any uncaught throw in any route returns a clean {error} response matching
+  // the API error shape instead of Express's default HTML page. The DB-heavy
+  // inline handlers (set-ready, set-ready-batch, recommission) are synchronous,
+  // so Express routes their throws here rather than crashing the process.
+  app.use((err, _req, res, _next) => {
+    console.error('[server] Unhandled route error:', err);
+    if (res.headersSent) return;
+    res.status(500).json({ error: 'Internal server error' });
+  });
 });
 
-module.exports = { app, server };
+module.exports = { app, get server() { return server; } };

--- a/server/index.js
+++ b/server/index.js
@@ -60,15 +60,26 @@ function shutdown(reason, exitCode) {
   shuttingDown = true;
   console.log(`[server] Shutting down (${reason})...`);
   try { poller?.stop(); } catch (_) {}
-  try { backup.stop(); } catch (_) {}
+  try { backup.stop(); } catch (_) {}   // stop SCHEDULING new backups
   try { drivers.closeAllConnections(); } catch (_) {}
+
+  // Absolute failsafe: force-exit after 5s no matter what — a lingering HTTP
+  // connection or an unexpectedly slow backup must never wedge shutdown.
+  setTimeout(() => process.exit(exitCode), 5000).unref();
+
   const finish = () => {
-    try { db.close(); } catch (_) {}
-    process.exit(exitCode);
+    // Wait for any in-flight online backup to finish before closing the DB, so we
+    // never terminate mid-`db.backup()` and leave a corrupt snapshot. `whenIdle`
+    // resolves immediately when no backup is running.
+    let idle;
+    try { idle = backup.whenIdle(); } catch (_) { idle = undefined; }
+    Promise.resolve(idle).catch(() => {}).then(() => {
+      try { db.close(); } catch (_) {}
+      process.exit(exitCode);
+    });
   };
   if (server) {
     server.close(finish);
-    setTimeout(finish, 5000).unref(); // force-exit if a connection lingers
   } else {
     finish();
   }

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,25 @@
+// Runtime state — declared before the crash handlers below so shutdown() is safe
+// to run even if a fault fires during module load (these stay null until startup).
+let poller       = null;
+let scheduler    = null;
+let server       = null;
+let shuttingDown = false;
+
+// Install the crash handlers FIRST — before any require() — so a synchronous throw
+// during module load or DB init is still logged via the guaranteed synchronous
+// stderr write, even if Node exits before stdout flushes (common on Windows).
+process.on('unhandledRejection', (reason) => {
+  // A single rejected promise (a flaky printer request, a driver hiccup) must not
+  // take the whole farm down. Log and keep running. (Previously: process.exit(1),
+  // which meant one unhandled rejection killed polling for all 50+ printers.)
+  process.stderr.write(`[WARN] unhandledRejection (continuing): ${reason?.stack || reason}\n`);
+});
+process.on('uncaughtException', (err) => {
+  // Unknown state: log, shut down cleanly, exit non-zero so PM2/Docker restarts us.
+  process.stderr.write(`[FATAL] uncaughtException: ${err.stack || err}\n`);
+  shutdown('uncaughtException', 1);
+});
+
 const express = require('express');
 const path    = require('path');
 const fs      = require('fs');
@@ -21,21 +43,24 @@ const modelsRouter       = require('./routes/models')(db);
 const filamentsRouter    = require('./routes/filaments')(db);
 const printerJobsRouter  = require('./routes/printer-jobs')(db);
 
-// ── Process resilience & graceful shutdown ───────────────────────────────────
 // Persist operator notifications to the DB so a crash/restart doesn't leave held
 // printers with no explanation of why.
 notifications.init(db);
 
-let poller       = null;
-let scheduler    = null;
-let server       = null;
-let shuttingDown = false;
+// Graceful shutdown on process-manager signals.
+process.on('SIGINT',  () => shutdown('SIGINT', 0));
+process.on('SIGTERM', () => shutdown('SIGTERM', 0));
 
+// Stop the poller and the hourly backup, tear down persistent printer connections,
+// close the DB, drain in-flight HTTP, then exit. Every step is guarded so an early
+// crash (before requires finished) still exits cleanly. `function` (hoisted) so the
+// crash handlers registered above can call it.
 function shutdown(reason, exitCode) {
   if (shuttingDown) return;
   shuttingDown = true;
   console.log(`[server] Shutting down (${reason})...`);
   try { poller?.stop(); } catch (_) {}
+  try { backup.stop(); } catch (_) {}
   try { drivers.closeAllConnections(); } catch (_) {}
   const finish = () => {
     try { db.close(); } catch (_) {}
@@ -48,24 +73,6 @@ function shutdown(reason, exitCode) {
     finish();
   }
 }
-
-process.on('SIGINT',  () => shutdown('SIGINT', 0));
-process.on('SIGTERM', () => shutdown('SIGTERM', 0));
-
-// A single rejected promise — a flaky printer request, a driver hiccup — must not
-// take the whole farm down. Log and keep running. (Previously: process.exit(1),
-// which meant one unhandled rejection killed polling for all 50+ printers.)
-process.on('unhandledRejection', (reason) => {
-  process.stderr.write(`[WARN] unhandledRejection (continuing): ${reason?.stack || reason}\n`);
-});
-
-// An uncaught exception leaves the process in an unknown state: log, shut down
-// cleanly (stop poller, drop printer connections, close DB), then exit non-zero
-// so PM2/Docker restarts us.
-process.on('uncaughtException', (err) => {
-  process.stderr.write(`[FATAL] uncaughtException: ${err.stack || err}\n`);
-  shutdown('uncaughtException', 1);
-});
 
 const app  = express();
 const PORT = process.env.PORT || 3000;

--- a/server/notifications.js
+++ b/server/notifications.js
@@ -1,26 +1,51 @@
-// In-memory notification store — survives as long as the server process is running.
-// Notifications are lost on restart, which is fine: actionable errors will recur
-// naturally on the next dispatch attempt if the underlying issue hasn't been fixed.
+// Operator notification store for recoverable server alerts (held printer with a
+// missing G-code, stale-job auto-cancel, upload failed after retries).
+//
+// Backed by the `notifications` table so alerts survive a crash/restart — a held
+// printer's *reason* is no longer lost when the process dies. Call init(db) once
+// at startup. Until then (or in unit tests that don't wire a DB) it falls back to
+// an in-memory list so add/list/dismiss keep working.
 
+let _db = null;
 let _nextId = 1;
-const _store = [];
+const _mem = [];
+
+function init(db) {
+  _db = db;
+}
 
 function add(message) {
-  const note = { id: _nextId++, message, timestamp: Date.now() };
-  _store.push(note);
+  const timestamp = Date.now();
   console.warn(`[notifications] ${message}`);
+  if (_db) {
+    const info = _db
+      .prepare('INSERT INTO notifications (message, created_at) VALUES (?, ?)')
+      .run(message, timestamp);
+    return { id: Number(info.lastInsertRowid), message, timestamp };
+  }
+  const note = { id: _nextId++, message, timestamp };
+  _mem.push(note);
   return note;
 }
 
 function list() {
-  return [..._store].reverse(); // newest first
+  if (_db) {
+    // `timestamp` alias preserves the API response shape (see docs/api.md).
+    return _db
+      .prepare('SELECT id, message, created_at AS timestamp FROM notifications ORDER BY created_at DESC, id DESC')
+      .all();
+  }
+  return [..._mem].reverse(); // newest first
 }
 
 function dismiss(id) {
-  const idx = _store.findIndex(n => n.id === id);
+  if (_db) {
+    return _db.prepare('DELETE FROM notifications WHERE id = ?').run(id).changes > 0;
+  }
+  const idx = _mem.findIndex(n => n.id === id);
   if (idx === -1) return false;
-  _store.splice(idx, 1);
+  _mem.splice(idx, 1);
   return true;
 }
 
-module.exports = { add, list, dismiss };
+module.exports = { init, add, list, dismiss };

--- a/server/poller.js
+++ b/server/poller.js
@@ -8,6 +8,7 @@ class PrinterPoller extends EventEmitter {
     super();
     this.db = db;
     this.timer = null;
+    this.lastPollAt = null; // epoch ms of the last completed tick — surfaced by /api/health
   }
 
   start() {
@@ -25,6 +26,7 @@ class PrinterPoller extends EventEmitter {
 
   async _tick() {
     if (process.env.DEMO_MODE === 'true') {
+      this.lastPollAt = Date.now();
       this.emit('pollComplete');
       return;
     }
@@ -33,7 +35,10 @@ class PrinterPoller extends EventEmitter {
       .prepare('SELECT * FROM printers WHERE is_active = 1')
       .all();
 
-    if (printers.length === 0) return;
+    if (printers.length === 0) {
+      this.lastPollAt = Date.now();
+      return;
+    }
 
     const results = await Promise.allSettled(
       printers.map((printer) => this._pollPrinter(printer))
@@ -45,6 +50,7 @@ class PrinterPoller extends EventEmitter {
       }
     });
 
+    this.lastPollAt = Date.now();
     this.emit('pollComplete');
   }
 

--- a/server/routes/backup.js
+++ b/server/routes/backup.js
@@ -3,6 +3,8 @@ const multer  = require('multer');
 const path    = require('path');
 const fs      = require('fs');
 
+const drivers  = require('../drivers');
+
 const router   = express.Router();
 const GCODE_DIR = path.join(__dirname, '..', 'gcode');
 
@@ -205,6 +207,11 @@ module.exports = (db) => {
       });
 
       restore();
+
+      // The printers table was wiped and reinserted (possibly with changed IPs or
+      // dropped ids). Stateful drivers cache a client per printer id, so drop them
+      // all — the next poll rebuilds each connection from the restored config.
+      try { drivers.closeAllConnections(); } catch (_) {}
 
       console.log(`[backup] Farm restored — ${backup.printers.length} printers, ${backup.projects.length} projects, ${backup.gcodes.length} gcodes, ${backup.jobs.length} jobs, ${(backup.printer_events || []).length} events, ${(backup.printer_models || []).length} printer models, ${(backup.filament_types || []).length} filament types, ${(backup.filament_colors || []).length} filament colors`);
 

--- a/server/routes/printers.js
+++ b/server/routes/printers.js
@@ -4,6 +4,7 @@ const Papa = require('papaparse');
 const axios = require('axios');
 const router = express.Router();
 const events = require('../events');
+const drivers = require('../drivers');
 
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -224,6 +225,7 @@ module.exports = (db) => {
   router.delete('/:id', (req, res) => {
     const printer = db.prepare('SELECT * FROM printers WHERE id = ?').get(req.params.id);
     if (!printer) return res.status(404).json({ error: 'Printer not found' });
+    drivers.dropConnection(printer); // tear down any persistent MQTT/WS connection
     db.prepare('DELETE FROM printers WHERE id = ?').run(req.params.id);
     res.json({ success: true });
   });
@@ -234,6 +236,7 @@ module.exports = (db) => {
     if (!printer) return res.status(404).json({ error: 'Printer not found' });
     const now = Date.now();
     db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ? WHERE id = ?').run(now, printer.id);
+    drivers.dropConnection(printer); // tear down any persistent MQTT/WS connection
     events.insert(printer.id, 'decommission', req.body?.note ?? null);
     console.log(`[printers] ${printer.name} decommissioned`);
     res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
@@ -315,6 +318,7 @@ module.exports = (db) => {
 
     const decommNote = req.body?.note ?? null;
     db.prepare('UPDATE printers SET is_active = 0, is_held = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, decommNote, printer.id);
+    drivers.dropConnection(printer); // tear down any persistent MQTT/WS connection
     events.insert(printer.id, 'decommission', decommNote ?? 'operator confirmed successful print — taken offline for maintenance');
     console.log(`[printers] ${printer.name} decommissioned after confirmed good print`);
     res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
@@ -370,6 +374,7 @@ module.exports = (db) => {
       const now = Date.now();
       const noJobNote = req.body?.note ?? null;
       db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, noJobNote, printer.id);
+      drivers.dropConnection(printer); // tear down any persistent MQTT/WS connection
       events.insert(printer.id, 'job_failed', noJobNote ?? 'No tracked job — printer decommissioned for investigation');
       console.log(`[printers] ${printer.name} decommissioned (no tracked job to mark failed)`);
       return res.json({ success: true, job_id: null });
@@ -405,6 +410,7 @@ module.exports = (db) => {
     // The operator must explicitly recommission it when the machine is confirmed safe.
     const failNote = req.body?.note ?? null;
     db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, failNote, printer.id);
+    drivers.dropConnection(printer); // tear down any persistent MQTT/WS connection
 
     const failedPart = db.prepare('SELECT name FROM parts WHERE id = ?').get(job.part_id);
     const eventNote = failNote

--- a/server/routes/printers.js
+++ b/server/routes/printers.js
@@ -212,6 +212,21 @@ module.exports = (db) => {
         }
       }
 
+      // If a connection-defining field changed, drop the stale cached driver
+      // connection (Bambu/Elegoo cache a client per printer.id and won't notice a
+      // new ip/access-code/serial/type on their own). Drop using the OLD printer row
+      // so a type change tears the connection down under its previous driver; the
+      // next poll rebuilds it from the updated settings.
+      const newApiKey = api_key !== undefined ? api_key : printer.api_key;
+      const connectionChanged =
+        after.ip !== printer.ip ||
+        after.type !== printer.type ||
+        after.serial_number !== printer.serial_number ||
+        newApiKey !== printer.api_key;
+      if (connectionChanged) {
+        drivers.dropConnection(printer);
+      }
+
       res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(req.params.id));
     } catch (err) {
       if (err.message.includes('UNIQUE')) {

--- a/server/tests/backup.test.js
+++ b/server/tests/backup.test.js
@@ -27,4 +27,19 @@ describe('backup.whenIdle', () => {
   test('resolves immediately when no backup is running', async () => {
     await expect(backup.whenIdle()).resolves.toBeUndefined();
   });
+
+  test('does not start a second backup while one is in flight (prevents overlap)', async () => {
+    let release;
+    let calls = 0;
+    const fakeDb = { backup: () => { calls++; return new Promise((r) => { release = r; }); } };
+
+    const first = backup.runBackup(fakeDb); // in flight — db.backup called once
+    await backup.runBackup(fakeDb);         // must skip immediately, not call db.backup again
+    expect(calls).toBe(1);
+
+    release();
+    await first;
+    // whenIdle is now accurate because _active was never overwritten by an overlapping run.
+    await expect(backup.whenIdle()).resolves.toBeUndefined();
+  });
 });

--- a/server/tests/backup.test.js
+++ b/server/tests/backup.test.js
@@ -1,0 +1,30 @@
+// Guards the graceful-shutdown fix: backup.whenIdle() must not resolve while an
+// online backup (db.backup) is in flight, so shutdown never closes the DB or exits
+// mid-copy and leaves a corrupt snapshot.
+
+const backup = require('../backup');
+
+describe('backup.whenIdle', () => {
+  test('waits for an in-flight backup before resolving', async () => {
+    let release;
+    // Controllable db.backup: stays pending until we release it.
+    const fakeDb = { backup: () => new Promise((r) => { release = r; }) };
+
+    const running = backup.runBackup(fakeDb); // in flight — intentionally not awaited
+    let idle = false;
+    const idleP = backup.whenIdle().then(() => { idle = true; });
+
+    // Let microtasks flush; whenIdle must still be pending while db.backup is.
+    await new Promise((r) => setImmediate(r));
+    expect(idle).toBe(false);
+
+    release();          // db.backup resolves
+    await running;      // runBackup finishes, clears the active handle
+    await idleP;
+    expect(idle).toBe(true);
+  });
+
+  test('resolves immediately when no backup is running', async () => {
+    await expect(backup.whenIdle()).resolves.toBeUndefined();
+  });
+});

--- a/server/tests/drivers-registry.test.js
+++ b/server/tests/drivers-registry.test.js
@@ -1,0 +1,49 @@
+// Verifies the driver registry (server/drivers/index.js): getDriver memoization
+// and unknown-type error, plus the connection-teardown dispatch added for Tier 1
+// (dropConnection on printer removal, closeAllConnections on shutdown).
+
+// Mock the Bambu driver so we can observe teardown dispatch without real MQTT.
+jest.mock('../drivers/bambu', () => ({
+  getStatus: jest.fn(),
+  uploadAndPrint: jest.fn(),
+  cancelJob: jest.fn(),
+  checkIfPrinting: jest.fn(),
+  dropConnection: jest.fn(),
+  closeAll: jest.fn(),
+}));
+
+const bambu = require('../drivers/bambu');
+const drivers = require('../drivers');
+
+describe('driver registry', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('getDriver returns the driver module and memoizes it', () => {
+    const a = drivers.getDriver('bambu');
+    const b = drivers.getDriver('bambu');
+    expect(a).toBe(bambu);
+    expect(b).toBe(a);
+  });
+
+  test('getDriver throws for an unknown type', () => {
+    expect(() => drivers.getDriver('nope')).toThrow(/No driver registered/);
+  });
+
+  test('dropConnection dispatches to the loaded driver with the printer id', () => {
+    drivers.getDriver('bambu'); // ensure loaded
+    drivers.dropConnection({ id: 42, type: 'bambu' });
+    expect(bambu.dropConnection).toHaveBeenCalledWith(42);
+  });
+
+  test('dropConnection is a safe no-op for a stateless / never-loaded driver', () => {
+    // 'prusa' has no dropConnection export and isn't loaded here — must not throw.
+    expect(() => drivers.dropConnection({ id: 1, type: 'prusa' })).not.toThrow();
+    expect(bambu.dropConnection).not.toHaveBeenCalled();
+  });
+
+  test('closeAllConnections calls closeAll on every loaded driver', () => {
+    drivers.getDriver('bambu');
+    drivers.closeAllConnections();
+    expect(bambu.closeAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/tests/drivers-registry.test.js
+++ b/server/tests/drivers-registry.test.js
@@ -1,5 +1,5 @@
-// Verifies the driver registry (server/drivers/index.js): getDriver memoization
-// and unknown-type error, plus the connection-teardown dispatch added for Tier 1
+// Verifies the driver registry (server/drivers/index.js): getDriver resolution and
+// unknown-type error, plus the connection-teardown dispatch added for Tier 1
 // (dropConnection on printer removal, closeAllConnections on shutdown).
 
 // Mock the Bambu driver so we can observe teardown dispatch without real MQTT.
@@ -18,11 +18,10 @@ const drivers = require('../drivers');
 describe('driver registry', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  test('getDriver returns the driver module and memoizes it', () => {
-    const a = drivers.getDriver('bambu');
-    const b = drivers.getDriver('bambu');
-    expect(a).toBe(bambu);
-    expect(b).toBe(a);
+  test('getDriver resolves a known type to its driver module', () => {
+    // Real functional assertion (not "same as itself"): the registry hands back
+    // the actual bambu module for type 'bambu'.
+    expect(drivers.getDriver('bambu')).toBe(bambu);
   });
 
   test('getDriver throws for an unknown type', () => {

--- a/server/tests/elegoo-driver.test.js
+++ b/server/tests/elegoo-driver.test.js
@@ -257,6 +257,45 @@ describe('checkIfPrinting', () => {
   });
 });
 
+// ─── dropConnection / closeAll (SDCP teardown) ────────────────────────────────
+
+describe('dropConnection / closeAll', () => {
+  test('turns OFF autoreconnect before disconnecting, then removes the client from the pool', async () => {
+    const printer = nextPrinter();
+    // Establish a pooled connection (getConnection sets AutoReconnect = 5000).
+    mockClient.GetStatus.mockResolvedValueOnce({ Status: { PrintInfo: { Status: 1 } } });
+    await elegoo.getStatus(printer);
+    expect(mockClient.AutoReconnect).toBe(5000);
+
+    elegoo.dropConnection(printer.id);
+
+    // AutoReconnect must be exactly `false` (a number would set a retry interval and
+    // the SDCPPrinterWS close handler would revive the socket we just dropped).
+    expect(mockClient.AutoReconnect).toBe(false);
+    expect(mockClient.Disconnect).toHaveBeenCalledTimes(1);
+
+    // Proof the pool entry was removed: the next poll reconstructs a fresh client.
+    SDCPPrinterWS.mockClear();
+    mockClient.GetStatus.mockResolvedValueOnce({ Status: { PrintInfo: { Status: 0 } } });
+    await elegoo.getStatus(printer);
+    expect(SDCPPrinterWS).toHaveBeenCalledTimes(1);
+  });
+
+  test('is a safe no-op for an unknown / never-connected printer id', () => {
+    expect(() => elegoo.dropConnection(987654)).not.toThrow();
+  });
+
+  test('closeAll disables autoreconnect and disconnects a pooled client', async () => {
+    const printer = nextPrinter();
+    mockClient.GetStatus.mockResolvedValueOnce({ Status: { PrintInfo: { Status: 1 } } });
+    await elegoo.getStatus(printer);
+
+    elegoo.closeAll();
+    expect(mockClient.AutoReconnect).toBe(false);
+    expect(mockClient.Disconnect).toHaveBeenCalled();
+  });
+});
+
 // ─── Driver registry ──────────────────────────────────────────────────────────
 
 describe('driver registry (drivers/index.js)', () => {

--- a/server/tests/notifications.test.js
+++ b/server/tests/notifications.test.js
@@ -1,0 +1,84 @@
+// Verifies the DB-backed notification store: alerts persist to the `notifications`
+// table so a crash/restart doesn't leave held printers with no explanation, and the
+// API response shape ({ id, message, timestamp }) is preserved. Also covers the
+// in-memory fallback used before init(db) / in tests that don't wire a DB.
+
+const Database = require('better-sqlite3');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+const notifications = require('../notifications');
+
+const SCHEMA = `CREATE TABLE IF NOT EXISTS notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  message TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);`;
+
+function memDb() {
+  const db = new Database(':memory:');
+  db.exec(SCHEMA);
+  return db;
+}
+
+function tmpFile() {
+  return path.join(os.tmpdir(), `pfm-notif-${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e6)}.db`);
+}
+
+describe('notifications (DB-backed)', () => {
+  let db;
+  beforeEach(() => { db = memDb(); notifications.init(db); });
+  afterEach(() => { notifications.init(null); db.close(); });
+
+  test('add persists a row and returns { id, message, timestamp }', () => {
+    const note = notifications.add('held: missing gcode');
+    expect(note).toMatchObject({ message: 'held: missing gcode' });
+    expect(typeof note.id).toBe('number');
+    expect(typeof note.timestamp).toBe('number');
+    const row = db.prepare('SELECT * FROM notifications WHERE id = ?').get(note.id);
+    expect(row.message).toBe('held: missing gcode');
+  });
+
+  test('list returns newest first with a timestamp field (API shape)', () => {
+    notifications.add('alert one');
+    notifications.add('alert two');
+    const list = notifications.list();
+    expect(list.map(n => n.message)).toEqual(['alert two', 'alert one']);
+    expect(list[0]).toHaveProperty('timestamp');
+    expect(list[0]).not.toHaveProperty('created_at');
+  });
+
+  test('dismiss removes a notification; unknown id returns false', () => {
+    const note = notifications.add('dismiss me');
+    expect(notifications.dismiss(note.id)).toBe(true);
+    expect(notifications.list()).toHaveLength(0);
+    expect(notifications.dismiss(99999)).toBe(false);
+  });
+});
+
+test('notifications survive a restart — a fresh DB connection still sees them', () => {
+  const file = tmpFile();
+  const db1 = new Database(file);
+  db1.exec(SCHEMA);
+  notifications.init(db1);
+  notifications.add('printer held: re-upload MK4S gcode');
+  db1.close(); // process "dies"
+
+  // New process boots against the same DB file.
+  const db2 = new Database(file);
+  notifications.init(db2);
+  expect(notifications.list().map(n => n.message)).toContain('printer held: re-upload MK4S gcode');
+  db2.close();
+  notifications.init(null);
+  fs.unlinkSync(file);
+});
+
+test('falls back to in-memory when no DB is initialized', () => {
+  notifications.init(null);
+  const note = notifications.add('mem only');
+  expect(note.message).toBe('mem only');
+  expect(notifications.list()[0].message).toBe('mem only');
+  expect(notifications.dismiss(note.id)).toBe(true);
+  expect(notifications.list()).toHaveLength(0);
+});

--- a/server/tests/notifications.test.js
+++ b/server/tests/notifications.test.js
@@ -59,19 +59,25 @@ describe('notifications (DB-backed)', () => {
 
 test('notifications survive a restart — a fresh DB connection still sees them', () => {
   const file = tmpFile();
-  const db1 = new Database(file);
-  db1.exec(SCHEMA);
-  notifications.init(db1);
-  notifications.add('printer held: re-upload MK4S gcode');
-  db1.close(); // process "dies"
+  try {
+    const db1 = new Database(file);
+    db1.exec(SCHEMA);
+    notifications.init(db1);
+    notifications.add('printer held: re-upload MK4S gcode');
+    db1.close(); // process "dies"
 
-  // New process boots against the same DB file.
-  const db2 = new Database(file);
-  notifications.init(db2);
-  expect(notifications.list().map(n => n.message)).toContain('printer held: re-upload MK4S gcode');
-  db2.close();
-  notifications.init(null);
-  fs.unlinkSync(file);
+    // New process boots against the same DB file.
+    const db2 = new Database(file);
+    notifications.init(db2);
+    expect(notifications.list().map(n => n.message)).toContain('printer held: re-upload MK4S gcode');
+    db2.close();
+  } finally {
+    // Always clean up, even if an assertion throws — including WAL sidecars.
+    notifications.init(null);
+    for (const f of [file, `${file}-wal`, `${file}-shm`]) {
+      try { fs.unlinkSync(f); } catch (_) {}
+    }
+  }
 });
 
 test('falls back to in-memory when no DB is initialized', () => {

--- a/server/tests/printers-dropconnection.test.js
+++ b/server/tests/printers-dropconnection.test.js
@@ -1,0 +1,125 @@
+// Guards the Tier 1 connection-leak fix: every path that removes a printer from the
+// fleet (delete + all four decommission routes) must call drivers.dropConnection with
+// the printer row, so a stateful driver's socket + reconnect loop is torn down. Without
+// these assertions, deleting any of the wiring lines in routes/printers.js is silent.
+
+const request  = require('supertest');
+const express  = require('express');
+const Database = require('better-sqlite3');
+
+const drivers = require('../drivers');
+
+let db;
+let app;
+let dropSpy;
+
+beforeAll(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE printers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE, ip TEXT NOT NULL, api_key TEXT NOT NULL DEFAULT '',
+      group_name TEXT, type TEXT DEFAULT 'prusa', model TEXT NOT NULL,
+      status TEXT DEFAULT 'UNKNOWN', is_held INTEGER DEFAULT 1, is_active INTEGER DEFAULT 1,
+      decommissioned_at INTEGER, decommission_note TEXT, serial_number TEXT DEFAULT '',
+      created_at INTEGER NOT NULL
+    );
+    CREATE TABLE projects (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, status TEXT DEFAULT 'active',
+      priority INTEGER DEFAULT 0, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE parts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, project_id INTEGER NOT NULL REFERENCES projects(id),
+      name TEXT NOT NULL, target_qty INTEGER NOT NULL, completed_qty INTEGER DEFAULT 0,
+      status TEXT DEFAULT 'open', sort_order INTEGER DEFAULT 0,
+      created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE gcodes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, part_id INTEGER NOT NULL REFERENCES parts(id),
+      printer_model TEXT NOT NULL, filename TEXT NOT NULL, filepath TEXT NOT NULL,
+      parts_per_plate INTEGER NOT NULL, est_print_secs INTEGER, created_at INTEGER NOT NULL
+    );
+    CREATE TABLE jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, part_id INTEGER NOT NULL REFERENCES parts(id),
+      printer_id INTEGER NOT NULL REFERENCES printers(id), gcode_id INTEGER NOT NULL REFERENCES gcodes(id),
+      parts_per_plate INTEGER NOT NULL, status TEXT DEFAULT 'queued',
+      started_at INTEGER, finished_at INTEGER, created_at INTEGER NOT NULL
+    );
+    CREATE TABLE printer_models ( model_id TEXT PRIMARY KEY, label TEXT NOT NULL, connector TEXT NOT NULL );
+  `);
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/printers', require('../routes/printers')(db));
+});
+
+beforeEach(() => {
+  // Spy on the real registry singleton the router imported. dropConnection is a
+  // no-op for stateless/unloaded drivers, but the spy still records the call.
+  dropSpy = jest.spyOn(drivers, 'dropConnection').mockImplementation(() => {});
+});
+
+afterEach(() => dropSpy.mockRestore());
+
+function seedPrinter(overrides = {}) {
+  const now = Date.now();
+  return db.prepare(
+    `INSERT INTO printers (name, ip, type, model, status, is_held, is_active, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    overrides.name ?? `P_${now}_${Math.floor(Math.random() * 1e6)}`,
+    overrides.ip ?? '10.0.0.9',
+    overrides.type ?? 'prusa',
+    overrides.model ?? 'mk4s',
+    overrides.status ?? 'FINISHED',
+    overrides.is_held ?? 1,
+    overrides.is_active ?? 1,
+    now
+  ).lastInsertRowid;
+}
+
+function seedFinishedJob(printerId) {
+  const now = Date.now();
+  const proj = db.prepare(`INSERT INTO projects (name, status, created_at, updated_at) VALUES ('P','active',?,?)`).run(now, now).lastInsertRowid;
+  const part = db.prepare(`INSERT INTO parts (project_id, name, target_qty, completed_qty, status, created_at, updated_at) VALUES (?, 'Part', 10, 4, 'open', ?, ?)`).run(proj, now, now).lastInsertRowid;
+  const gc = db.prepare(`INSERT INTO gcodes (part_id, printer_model, filename, filepath, parts_per_plate, created_at) VALUES (?, 'mk4s', 'p.bgcode', '/x/p.bgcode', 4, ?)`).run(part, now).lastInsertRowid;
+  db.prepare(`INSERT INTO jobs (printer_id, part_id, gcode_id, parts_per_plate, status, started_at, finished_at, created_at) VALUES (?, ?, ?, 4, 'finished', ?, ?, ?)`).run(printerId, part, gc, now - 3600000, now, now - 3600000);
+}
+
+test('DELETE /:id drops the connection, with the printer row (id + type)', async () => {
+  const id = seedPrinter({ type: 'bambu', model: 'x1c' });
+  const res = await request(app).delete(`/api/printers/${id}`);
+  expect(res.status).toBe(200);
+  expect(dropSpy).toHaveBeenCalledTimes(1);
+  expect(dropSpy).toHaveBeenCalledWith(expect.objectContaining({ id, type: 'bambu' }));
+});
+
+test('POST /:id/decommission drops the connection', async () => {
+  const id = seedPrinter();
+  const res = await request(app).post(`/api/printers/${id}/decommission`);
+  expect(res.status).toBe(200);
+  expect(dropSpy).toHaveBeenCalledWith(expect.objectContaining({ id }));
+});
+
+test('POST /:id/complete-and-decommission drops the connection', async () => {
+  const id = seedPrinter();
+  seedFinishedJob(id);
+  const res = await request(app).post(`/api/printers/${id}/complete-and-decommission`).send({ note: 'maint' });
+  expect(res.status).toBe(200);
+  expect(dropSpy).toHaveBeenCalledWith(expect.objectContaining({ id }));
+});
+
+test('POST /:id/mark-job-failure drops the connection', async () => {
+  const id = seedPrinter();
+  seedFinishedJob(id);
+  const res = await request(app).post(`/api/printers/${id}/mark-job-failure`);
+  expect(res.status).toBe(200);
+  expect(dropSpy).toHaveBeenCalledWith(expect.objectContaining({ id }));
+});
+
+test('a 404 (unknown printer) does not call dropConnection', async () => {
+  await request(app).delete('/api/printers/99999');
+  await request(app).post('/api/printers/99999/decommission');
+  expect(dropSpy).not.toHaveBeenCalled();
+});

--- a/server/tests/printers-dropconnection.test.js
+++ b/server/tests/printers-dropconnection.test.js
@@ -23,6 +23,7 @@ beforeAll(() => {
       group_name TEXT, type TEXT DEFAULT 'prusa', model TEXT NOT NULL,
       status TEXT DEFAULT 'UNKNOWN', is_held INTEGER DEFAULT 1, is_active INTEGER DEFAULT 1,
       decommissioned_at INTEGER, decommission_note TEXT, serial_number TEXT DEFAULT '',
+      loaded_material TEXT, loaded_color TEXT,
       created_at INTEGER NOT NULL
     );
     CREATE TABLE projects (
@@ -121,5 +122,27 @@ test('POST /:id/mark-job-failure drops the connection', async () => {
 test('a 404 (unknown printer) does not call dropConnection', async () => {
   await request(app).delete('/api/printers/99999');
   await request(app).post('/api/printers/99999/decommission');
+  expect(dropSpy).not.toHaveBeenCalled();
+});
+
+// --- PUT: connection-defining fields ---------------------------------------
+
+test.each([
+  ['ip', { ip: '10.0.0.99' }],
+  ['api_key (access code)', { api_key: 'new-access-code' }],
+  ['serial_number', { serial_number: 'SN-CHANGED' }],
+])('PUT that changes %s drops the stale connection with the OLD printer row', async (_label, body) => {
+  const id = seedPrinter({ type: 'bambu', model: 'x1c', ip: '10.0.0.9', api_key: 'old', serial_number: 'SN-OLD' });
+  const res = await request(app).put(`/api/printers/${id}`).send(body);
+  expect(res.status).toBe(200);
+  // Dropped using the pre-update row (old type/id) so a driver change tears down
+  // the connection under its previous driver.
+  expect(dropSpy).toHaveBeenCalledWith(expect.objectContaining({ id, type: 'bambu' }));
+});
+
+test('PUT that changes only a non-connection field does NOT drop the connection', async () => {
+  const id = seedPrinter({ type: 'bambu', model: 'x1c' });
+  const res = await request(app).put(`/api/printers/${id}`).send({ group_name: 'Bay 4' });
+  expect(res.status).toBe(200);
   expect(dropSpy).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
Hardens the server's failure modes so a single fault can't take the whole farm
down, a restart never loses operator context, and a wedged process is
detectable. Touches nothing in the `completed_qty` / part-count credit path.

## Changes
- **Crash resilience** — `unhandledRejection` now logs and continues (was
  `process.exit(1)`, which let one rejected driver/network promise kill polling
  for all 50+ printers). `uncaughtException` shuts down cleanly, then exits non-zero.
- **Graceful shutdown** — `SIGINT`/`SIGTERM` stop the poller + hourly backup,
  tear down persistent printer connections, close the DB, and drain HTTP before
  exit (5s failsafe). Fires on PM2 restart, `docker stop`, and console Ctrl+C.
- **Persisted operator alerts** — recoverable notifications (held printer w/
  missing G-code, stale-job auto-cancel, upload-failed-after-retries) now live in
  a `notifications` table, so a crash no longer leaves held printers with no
  explanation. In-memory fallback retained; API response shape unchanged.
- **Connection teardown** — Bambu/Elegoo drivers export `dropConnection`/`closeAll`;
  the registry drops a printer's socket on delete + every decommission path, and
  closes all connections on shutdown. Fixes a per-printer MQTT/WS reconnect-loop leak.
- **Deep health check** — `/api/health` runs `SELECT 1` and reports last-poll age;
  returns `503` when the DB is down or polling is stale >60s. New fields: `db`,
  `last_poll_at`, `poll_age_ms`.
- **Global JSON error handler** — uncaught route throws return `{ error }` instead
  of Express's default HTML 500.

## Testing
- Full suite: **27 suites / 402 tests** pass (was 24/387).
- An adversarial multi-agent review of this diff confirmed **no part-count risk
  and no crash bugs**; every P3 issue it surfaced (elegoo connect-window leak,
  crash-handler placement, stale connections after restore, backup/shutdown race)
  is fixed in this branch.
- Live: `/api/health` verified green; notification persistence verified cross-process.

## Notes
- Follows project conventions: synchronous DB, additive `CREATE TABLE IF NOT EXISTS`
  (no migration framework), no changes to `completed_qty` handling.
- Documented follow-up: direct tests for `shutdown()` ordering / health branches /
  the error handler would need an `if (require.main === module)` listen guard so
  `index.js` is importable without booting — deferred (regression-protection only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
