### PR TITLE
fix(klipper): make Moonraker port configurable via host:port in ip field

### DIFF
--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -38,7 +38,7 @@ const CREDENTIAL_HELP = {
   'elegoo-centauri':  'No API key needed — just the printer\'s IP address, shown on the printer\'s network settings screen.',
   'elegoo-centauri2': 'Enable LAN mode on the printer. The Access Code and Serial Number are shown on the printer\'s network settings screen.',
   'bambu':            'Enable LAN Mode on the printer first. The Access Code is on the printer screen under Settings → WLAN; the Serial Number is under Settings → Device.',
-  'klipper':          'No API key needed — just the IP of the machine running Moonraker. Port 7125 is used automatically.',
+  'klipper':          'No API key needed, just the IP of the machine running Moonraker. Defaults to port 7125; if you\'re running multiple Klipper/Moonraker instances on one host, include the port in the IP field, e.g. 192.168.1.50:7126.',
   'octoprint':        'API Key: in OctoPrint under Settings → API. If OctoPrint isn\'t on port 80 (commonly :5000), include the port in the IP field, e.g. 192.168.1.50:5000.',
 };
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ---
 
+## 2026-07-16: configurable Moonraker port for the Klipper connector
+
+The Klipper driver hardcoded Moonraker's port as 7125 for every printer, so an operator running multiple Klipper/Moonraker instances behind one host (for example several mainboards bridged through a single Raspberry Pi) had no way to reach any instance but the one on the default port.
+
+Fixed by letting the printer's IP field optionally carry a `host:port` suffix, exactly like the existing OctoPrint driver already does. If no port is given, the driver still defaults to 7125, so every existing Klipper printer and G-code keeps working unchanged with no action required.
+
+Driver-only change: the Moonraker query, upload, and cancel request logic are untouched, only how the target URL is assembled. Implemented from the existing driver contract and covered by mocked tests (default port, custom port, and custom port combined with a stray `http://` prefix); not separately re-validated against real Klipper hardware beyond the existing mocked suite, since the underlying protocol calls did not change.
+
+### Changes
+- `server/drivers/klipper.js`: renamed `PORT` to `DEFAULT_PORT`; `base()` now parses an optional `:port` suffix off the cleaned `ip` field and falls back to `DEFAULT_PORT` when absent.
+- `server/tests/klipper-driver.test.js`: added tests for a custom port and for a custom port combined with a stripped `http://` prefix.
+- `client/src/pages/Settings.jsx`: reworded the Klipper `CREDENTIAL_HELP` text to document the default port and the host:port override.
+- `docs/installation.md`: updated the Klipper credentials table row to mention the host:port override.
+- `docs/driver-authoring.md`: updated the `printer.ip` contract row and the Klipper reference-implementation row to describe the default-plus-override pattern instead of a purely fixed port.
+
 ## 2026-07-12: dispatch_batch_size means concurrent uploads, not printers considered per pass
 
 Joel batch-confirmed a stack of held printers via Fleet's "Set Ready (N)" button with `dispatch_batch_size` set to 5, and instead of 5 uploads running at once he saw 3 or 4. He walked through it precisely: some of the held printers had the wrong material or color loaded for the part they'd match, so the scheduler correctly found "no candidate" for them and moved on without creating a job, exactly as designed. The bug was in what happened next. `_sweepInBatches` chunked the confirmed printers into fixed slices of `dispatch_batch_size` and processed one slice at a time, waiting for the whole slice to settle before moving to the next. If a slice of 5 had only 1 real candidate, only 1 upload ran, and the scheduler moved on to the *next fixed slice of 5* instead of reaching further into the queue to make up the difference. Joel's framing was the fix: "if I have five set as my limit, then five should be uploading at once, not five being contacted at once with one of the five being able to print."

--- a/docs/driver-authoring.md
+++ b/docs/driver-authoring.md
@@ -56,7 +56,7 @@ Fields your driver can rely on:
 | Field | Meaning |
 |---|---|
 | `printer.id` | Stable numeric ID. Use as the key for any module-level connection Map. |
-| `printer.ip` | Host, possibly with a port (`192.168.1.50:5000`). Never assume port 80 is implied if your protocol uses another port; either document a fixed port (Klipper uses 7125) or accept host:port in this field (OctoPrint pattern). |
+| `printer.ip` | Host, possibly with a port (`192.168.1.50:5000`). Never assume port 80 is implied if your protocol uses another port; either document a fixed port or accept an optional host:port in this field with a sensible default (Klipper defaults to 7125, OctoPrint has no default and always expects the port in the field when it isn't 80). |
 | `printer.api_key` | Whatever secret your protocol needs. The column name is historical: Bambu stores its LAN access code here, Elegoo SDCP and Klipper store `''`. |
 | `printer.serial_number` | Used by protocols that need a device ID (Bambu MQTT topics, CC2). `''` otherwise. |
 | `printer.name` | Operator-facing display name. Use it in log lines. |
@@ -202,7 +202,7 @@ Automated tests with mocked networks catch mapping bugs; they cannot catch a pro
 |---|---|---|
 | `octoprint.js` | Stateless HTTP | The cleanest recent example; synthesized FINISHED detection |
 | `prusa.js` | Stateless HTTP | UPLOAD_CONFLICT handling, pre-delete before upload |
-| `klipper.js` | Stateless HTTP | Fixed non-80 port convention |
+| `klipper.js` | Stateless HTTP | Default non-80 port with host:port override in the ip field |
 | `bambu.js` | Persistent (MQTT) | Connection Map, cached push state, partial-update merging, STOPPED/ERROR disambiguation, optional `deleteFile` |
 | `elegoo-centauri.js` | Persistent (WebSocket) | Request/response correlation over a socket |
 | `elegoo-centauri2.js` | Persistent (MQTT) + chunked HTTP upload | Mixed-transport protocols |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -99,7 +99,7 @@ Before adding printers to the app, gather the following credentials. The app wil
 | **Bambu Lab** | IP address + serial number + access code | Enable **LAN Mode** on the printer first. The access code is on the printer screen under **Settings → WLAN**; the serial number is under **Settings → Device**. The access code changes every time LAN Mode is toggled. |
 | **Elegoo Centauri Carbon** | IP address only | Printer touchscreen: **Settings → Network**. No access code required. |
 | **Elegoo Centauri Carbon 2** | IP address + serial number + access code | Enable LAN mode on the printer. The access code and serial number are shown on the printer's network settings screen. |
-| **Klipper (Voron, etc.)** | IP address of the Klipper host | The IP of the machine running Moonraker (same machine as Klipper). Port 7125 is used automatically. No API key required. |
+| **Klipper (Voron, etc.)** | IP address of the Klipper host | The IP of the machine running Moonraker (same machine as Klipper). Defaults to port 7125; if you run multiple Moonraker instances on one host, include the port in the IP field, e.g. `192.168.1.50:7126`. No API key required. |
 | **OctoPrint** | IP address (with port) + API key | In OctoPrint: **Settings → API** shows the key. If OctoPrint is not on port 80, include the port in the IP field — e.g. `192.168.1.50:5000` (OctoPi commonly uses `:5000`). |
 
 ---

--- a/server/drivers/klipper.js
+++ b/server/drivers/klipper.js
@@ -1,4 +1,4 @@
-// Klipper driver — Moonraker REST API (HTTP polling, port 7125)
+// Klipper driver, Moonraker REST API (HTTP polling, default port 7125)
 // Implements the shared driver interface: getStatus, uploadAndPrint, cancelJob, checkIfPrinting
 //
 // Moonraker is the standard API layer for Klipper firmware (Voron, etc.).
@@ -9,12 +9,16 @@ const axios = require('axios');
 const fs = require('fs');
 const FormData = require('form-data');
 
-const PORT = 7125;
+const DEFAULT_PORT = 7125;
 
 function base(printer) {
   // Strip any accidental protocol prefix or trailing slashes — field expects bare IP.
-  const ip = printer.ip.replace(/^https?:\/\//, '').replace(/\/+$/, '');
-  return `http://${ip}:${PORT}`;
+  const cleaned = printer.ip.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  // Optional ":port" suffix lets multiple Moonraker instances share one host.
+  const match = cleaned.match(/^(.+):(\d+)$/);
+  const host = match ? match[1] : cleaned;
+  const port = match ? match[2] : DEFAULT_PORT;
+  return `http://${host}:${port}`;
 }
 
 // ─── Status ─────────────────────────────────────────────────────────────────

--- a/server/tests/klipper-driver.test.js
+++ b/server/tests/klipper-driver.test.js
@@ -147,6 +147,26 @@ describe('getStatus', () => {
       expect.anything()
     );
   });
+
+  test('uses a custom port when the ip field includes host:port', async () => {
+    const customPortPrinter = { ...fakePrinter, ip: '192.168.1.250:7126' };
+    axios.get.mockResolvedValueOnce(moonrakerResponse('standby'));
+    await klipper.getStatus(customPortPrinter);
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://192.168.1.250:7126/printer/objects/query',
+      expect.anything()
+    );
+  });
+
+  test('strips http:// prefix and honors a custom port together', async () => {
+    const messyCustomPortPrinter = { ...fakePrinter, ip: 'http://192.168.1.250:7126/' };
+    axios.get.mockResolvedValueOnce(moonrakerResponse('standby'));
+    await klipper.getStatus(messyCustomPortPrinter);
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://192.168.1.250:7126/printer/objects/query',
+      expect.anything()
+    );
+  });
 });
 
 // ─── uploadAndPrint ───────────────────────────────────────────────────────────


### PR DESCRIPTION
The Klipper driver hardcoded Moonraker's port as 7125, so an operator running multiple Klipper/Moonraker instances behind one host had no way to reach any instance but the one on the default port. The ip field now accepts an optional host:port suffix, same pattern already used by the OctoPrint driver, and still defaults to 7125 when no port is given so existing installs are unaffected.