### PR TITLE
fix(printers): drop cached driver connections on edit, delete, and decommission

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,24 @@ Fixed by adding `priority ASC` to the dashboard's active-projects query, matchin
 - `server/tests/dashboard.test.js` (new): covers priority ordering, the `created_at` tiebreaker, and exclusion of non-active projects.
 - `docs/api.md`, `docs/web-app.md`: documented that `active_projects` and the Dashboard's Active Projects panel are ordered by priority, matching the Projects page.
 
+## 2026-07-24: printer edits now reach the driver without a server restart
+
+Reported from a live two-printer Bambu farm. The operator added a P1S with a mistyped access code, then corrected the code on the Settings page, and the printer stayed OFFLINE anyway: the Bambu driver's cached MQTT client kept retrying auth with the original wrong code, because nothing ever told the driver the row had changed. Connection-relevant edits only took effect after a full server restart. The same gap had a second, sneakier symptom on the same farm: a duplicate printer row that was decommissioned (and could have been deleted) left behind a ghost MQTT client that reconnected forever, and since a Bambu printer accepts a single LAN client, the ghost and the real entry kicked each other offline in a loop that looked like a flaky printer.
+
+Persistent-connection drivers (bambu, elegoo-centauri, elegoo-centauri2) keep a module-level Map of `printer.id` to a live client that auto-reconnects with the credentials it was created with. The fix is a `dropConnection` contract: each persistent driver exports its existing internal drop helper, the registry exposes `dropConnection(type, printerId)` (a no-op for stateless drivers and never force-loads a lazy driver), and the printer routes call it whenever `ip`, `api_key`, `serial_number`, or `type` changes on PUT, and on DELETE and all three decommission paths. The next poll recreates the connection from the current row.
+
+Validated on hardware: reproduced the wrong-access-code symptom on a real P1S, applied the fix, and confirmed the corrected code connected on the next poll with no restart.
+
+### Changes
+- `server/drivers/bambu.js`: export `dropConnection` (already implemented, previously unreachable).
+- `server/drivers/elegoo-centauri.js`, `server/drivers/elegoo-centauri2.js`: export their existing `dropConnection` helpers.
+- `server/drivers/index.js`: registry-level `dropConnection(type, printerId)`; tracks loaded drivers so dropping never triggers a lazy require.
+- `server/routes/printers.js`: PUT drops the cached connection when a connection-relevant field changes (api_key compared against the request body, since it is deliberately excluded from event logging); DELETE, `decommission`, `complete-and-decommission`, and `mark-job-failure` always drop it.
+- `server/tests/bambu-driver.test.js`: 3 new tests (client ended, reconnect uses fresh credentials, no-op for unknown id).
+- `server/tests/printers-connection-drop.test.js`: new suite covering every route path that must (and must not) drop, plus the registry helper's no-op guarantees.
+- `docs/driver-authoring.md`: `dropConnection` added to the optional exports contract.
+- `docs/api.md`: connection-drop behavior noted on PUT and DELETE.
+
 ## 2026-07-04: fix adding a part to a completed project couldn't be reactivated
 
 Reported: adding a new part to a project that had already completed left the project stuck, clicking Re-activate returned "All parts are at target qty, adjust quantities first" even though the new part clearly had remaining qty (0/1).
@@ -60,6 +78,7 @@ Verified all three trigger points again, this time driven through the actual bro
 - `docs/api.md`: documented the reactivation/sweep behavior on `POST /api/parts`, `PUT /api/parts/:id`, and `POST /api/gcodes/upload`; corrected the `POST /api/parts` wording in round 3.
 
 ---
+
 ## 2026-07-12: dispatch_batch_size means concurrent uploads, not printers considered per pass
 
 Joel batch-confirmed a stack of held printers via Fleet's "Set Ready (N)" button with `dispatch_batch_size` set to 5, and instead of 5 uploads running at once he saw 3 or 4. He walked through it precisely: some of the held printers had the wrong material or color loaded for the part they'd match, so the scheduler correctly found "no candidate" for them and moved on without creating a job, exactly as designed. The bug was in what happened next. `_sweepInBatches` chunked the confirmed printers into fixed slices of `dispatch_batch_size` and processed one slice at a time, waiting for the whole slice to settle before moving to the next. If a slice of 5 had only 1 real candidate, only 1 upload ran, and the scheduler moved on to the *next fixed slice of 5* instead of reaching further into the queue to make up the difference. Joel's framing was the fix: "if I have five set as my limit, then five should be uploading at once, not five being contacted at once with one of the five being able to print."

--- a/docs/api.md
+++ b/docs/api.md
@@ -102,6 +102,8 @@ Returns `201` with the created printer object. Returns `409` if `name` already e
 
 Partial update — only fields provided are changed (uses `COALESCE`). All fields from POST are accepted, plus `is_held` (`0` or `1`).
 
+Changing `ip`, `api_key`, `serial_number`, or `type` drops the driver's cached connection for this printer, so the new settings take effect on the next poll (about 15 seconds) with no server restart.
+
 Returns `404` if not found, `409` on name conflict.
 
 ### `DELETE /api/printers/:id`
@@ -109,6 +111,8 @@ Returns `404` if not found, `409` on name conflict.
 ```json
 { "success": true }
 ```
+
+Also drops the driver's cached connection for this printer. Decommissioning (all three variants: `decommission`, `complete-and-decommission`, `mark-job-failure`) does the same, so an inactive row can never hold a live client that competes with a replacement entry for the same physical printer.
 
 Returns `404` if not found.
 

--- a/docs/driver-authoring.md
+++ b/docs/driver-authoring.md
@@ -47,6 +47,16 @@ deleteFile(printer, filename)
   → if exported, the scheduler calls it after a job finishes to clean the
     file off the printer's storage (see bambu.js). Fire-and-forget: errors
     are swallowed by the caller.
+
+dropConnection(printerId)
+  → REQUIRED for persistent-connection drivers, not used by stateless ones.
+    Close and forget any cached client for this printer id. The routes layer
+    calls it (via the registry's dropConnection(type, printerId)) whenever an
+    operator edits a printer's ip, api_key, serial_number, or type, and when
+    a printer is deleted or decommissioned. Without it, a cached client keeps
+    reconnecting with the credentials it was created with until the server
+    restarts, and a deleted row's client reconnects forever. Must be a no-op
+    for an id with no cached connection.
 ```
 
 ### The `printer` row
@@ -203,6 +213,6 @@ Automated tests with mocked networks catch mapping bugs; they cannot catch a pro
 | `octoprint.js` | Stateless HTTP | The cleanest recent example; synthesized FINISHED detection |
 | `prusa.js` | Stateless HTTP | UPLOAD_CONFLICT handling, pre-delete before upload |
 | `klipper.js` | Stateless HTTP | Fixed non-80 port convention |
-| `bambu.js` | Persistent (MQTT) | Connection Map, cached push state, partial-update merging, STOPPED/ERROR disambiguation, optional `deleteFile` |
+| `bambu.js` | Persistent (MQTT) | Connection Map, cached push state, partial-update merging, STOPPED/ERROR disambiguation, optional `deleteFile`, `dropConnection` |
 | `elegoo-centauri.js` | Persistent (WebSocket) | Request/response correlation over a socket |
 | `elegoo-centauri2.js` | Persistent (MQTT) + chunked HTTP upload | Mixed-transport protocols |

--- a/server/drivers/bambu.js
+++ b/server/drivers/bambu.js
@@ -101,6 +101,10 @@ function getOrCreateConnection(printer) {
   return conn;
 }
 
+// Close and forget the cached MQTT connection for a printer. The next getStatus
+// call recreates it from the printer row it is given, so credential or address
+// edits take effect without a server restart. Also the only way to stop the
+// client's auto-reconnect loop once a printer row is deleted or decommissioned.
 function dropConnection(printerId) {
   const conn = connections.get(printerId);
   if (conn) {
@@ -382,4 +386,4 @@ async function checkIfPrinting(printer) {
   return status === 'PRINTING' || status === 'PAUSED';
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, getAmsSlots, deleteFile };
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, getAmsSlots, deleteFile, dropConnection };

--- a/server/drivers/elegoo-centauri.js
+++ b/server/drivers/elegoo-centauri.js
@@ -227,4 +227,4 @@ async function checkIfPrinting(printer) {
   }
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting };
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, dropConnection };

--- a/server/drivers/elegoo-centauri2.js
+++ b/server/drivers/elegoo-centauri2.js
@@ -392,4 +392,4 @@ async function checkIfPrinting(printer) {
   }
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting };
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, dropConnection };

--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -15,10 +15,30 @@ const LOADERS = {
   'octoprint':        () => require('./octoprint'),
 };
 
+// Drivers that have actually been loaded this process. Used by dropConnection
+// so it never forces a lazy driver to load just to tell it "forget printer N".
+const loaded = new Map();
+
 function getDriver(type) {
   const load = LOADERS[type];
   if (!load) throw new Error(`No driver registered for printer type: "${type}"`);
-  return load();
+  if (!loaded.has(type)) loaded.set(type, load());
+  return loaded.get(type);
 }
 
-module.exports = { getDriver };
+// Tell a driver to discard any cached connection state for one printer.
+// Persistent-connection drivers (bambu, elegoo-centauri, elegoo-centauri2) keep a
+// module-level Map of printer.id to a live client that reconnects on its own with
+// the credentials it was created with. Callers must invoke this whenever a printer's
+// connection settings change (ip, api_key, serial_number, type) or the row leaves
+// active duty (delete, decommission), or the stale client shadows the new settings
+// until the next server restart.
+// Safe to call for any type: request/response drivers simply have no dropConnection.
+function dropConnection(type, printerId) {
+  const driver = loaded.get(type);
+  if (driver && typeof driver.dropConnection === 'function') {
+    driver.dropConnection(printerId);
+  }
+}
+
+module.exports = { getDriver, dropConnection };

--- a/server/routes/printers.js
+++ b/server/routes/printers.js
@@ -4,6 +4,7 @@ const Papa = require('papaparse');
 const axios = require('axios');
 const router = express.Router();
 const events = require('../events');
+const { dropConnection } = require('../drivers');
 
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -218,6 +219,23 @@ module.exports = (db) => {
         }
       }
 
+      // If anything the driver connects with changed, drop the cached connection so
+      // the next poll reconnects with the new settings. Persistent drivers otherwise
+      // keep retrying with the values they were created with until a server restart.
+      // api_key is checked from the body (COALESCE semantics: null/omitted keeps the
+      // old value) because it is deliberately absent from FIELD_LABELS: logging an
+      // access code change would write the secret into the event history.
+      const connectionChanged =
+        after.ip            !== printer.ip ||
+        after.serial_number !== printer.serial_number ||
+        after.type          !== printer.type ||
+        (api_key != null && api_key !== printer.api_key);
+      if (connectionChanged) {
+        // printer.type, not after.type: the cached connection lives under the old driver.
+        dropConnection(printer.type, printer.id);
+        console.log(`[printers] ${after.name} connection settings changed, dropped cached driver connection`);
+      }
+
       res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(req.params.id));
     } catch (err) {
       if (err.message.includes('UNIQUE')) {
@@ -232,6 +250,8 @@ module.exports = (db) => {
     const printer = db.prepare('SELECT * FROM printers WHERE id = ?').get(req.params.id);
     if (!printer) return res.status(404).json({ error: 'Printer not found' });
     db.prepare('DELETE FROM printers WHERE id = ?').run(req.params.id);
+    // The row is gone; without this the driver's client would auto-reconnect forever.
+    dropConnection(printer.type, printer.id);
     res.json({ success: true });
   });
 
@@ -242,6 +262,10 @@ module.exports = (db) => {
     const now = Date.now();
     db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ? WHERE id = ?').run(now, printer.id);
     events.insert(printer.id, 'decommission', req.body?.note ?? null);
+    // The poller skips inactive printers, but a persistent driver client would keep
+    // auto-reconnecting on its own. On Bambu that steals the printer's single LAN
+    // slot from any replacement row pointed at the same machine.
+    dropConnection(printer.type, printer.id);
     console.log(`[printers] ${printer.name} decommissioned`);
     res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
   });
@@ -323,6 +347,7 @@ module.exports = (db) => {
     const decommNote = req.body?.note ?? null;
     db.prepare('UPDATE printers SET is_active = 0, is_held = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, decommNote, printer.id);
     events.insert(printer.id, 'decommission', decommNote ?? 'operator confirmed successful print — taken offline for maintenance');
+    dropConnection(printer.type, printer.id);
     console.log(`[printers] ${printer.name} decommissioned after confirmed good print`);
     res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
   });
@@ -378,6 +403,7 @@ module.exports = (db) => {
       const noJobNote = req.body?.note ?? null;
       db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, noJobNote, printer.id);
       events.insert(printer.id, 'job_failed', noJobNote ?? 'No tracked job — printer decommissioned for investigation');
+      dropConnection(printer.type, printer.id);
       console.log(`[printers] ${printer.name} decommissioned (no tracked job to mark failed)`);
       return res.json({ success: true, job_id: null });
     }
@@ -418,6 +444,7 @@ module.exports = (db) => {
       ? `Job ${job.id} — part: ${failedPart?.name ?? 'unknown'} — ${failNote}`
       : `Job ${job.id} — part: ${failedPart?.name ?? 'unknown'}`;
     events.insert(printer.id, 'job_failed', eventNote);
+    dropConnection(printer.type, printer.id);
 
     console.log(`[printers] Job ${job.id} marked failed — ${printer.name} decommissioned pending investigation`);
     res.json({ success: true, job_id: job.id });

--- a/server/tests/bambu-driver.test.js
+++ b/server/tests/bambu-driver.test.js
@@ -146,6 +146,44 @@ describe('getAmsSlots', () => {
   });
 });
 
+// ─── dropConnection ───────────────────────────────────────────────────────────
+// The connection cache is keyed by printer.id and clients reconnect on their own
+// with the credentials they were created with. dropConnection is how the routes
+// layer forces a reconnect after an operator edits ip/api_key/serial_number, or
+// stops the reconnect loop entirely after a delete/decommission.
+
+describe('dropConnection', () => {
+  test('ends the MQTT client with force=true', () => {
+    const printer = nextPrinter();
+    bambu.getStatus(printer); // creates the cached connection
+    bambu.dropConnection(printer.id);
+    expect(mockMqttClient.end).toHaveBeenCalledWith(true);
+  });
+
+  test('next getStatus reconnects using the credentials it is given', async () => {
+    const printer = nextPrinter();
+    pushStatus(printer, { gcode_state: 'IDLE' });
+    expect(mqtt.connect).toHaveBeenCalledTimes(1);
+
+    // Same status call again: cached, no new client.
+    await bambu.getStatus(printer);
+    expect(mqtt.connect).toHaveBeenCalledTimes(1);
+
+    bambu.dropConnection(printer.id);
+
+    // Operator fixed a mistyped access code; the poller passes the updated row.
+    const updated = { ...printer, api_key: 'NEWCODE1' };
+    await bambu.getStatus(updated);
+    expect(mqtt.connect).toHaveBeenCalledTimes(2);
+    expect(mqtt.connect.mock.calls[1][1].password).toBe('NEWCODE1');
+  });
+
+  test('is a no-op for a printer with no cached connection', () => {
+    expect(() => bambu.dropConnection(999999)).not.toThrow();
+    expect(mockMqttClient.end).not.toHaveBeenCalled();
+  });
+});
+
 // ─── getStatus — FAILED disambiguation ───────────────────────────────────────
 // Bambu reports user-cancelled prints as gcode_state FAILED, same as genuine
 // failures. print_error tells them apart: 50348044 = cancelled by user (resets

--- a/server/tests/printers-connection-drop.test.js
+++ b/server/tests/printers-connection-drop.test.js
@@ -1,0 +1,194 @@
+// Tests that printer routes invalidate the driver's cached connection whenever
+// connection settings change or the row leaves active duty.
+//
+// Regression context: persistent-connection drivers (bambu, elegoo-centauri,
+// elegoo-centauri2) keep a module-level client per printer.id that reconnects on
+// its own with the credentials it was created with. Before this fix, editing a
+// printer's access code kept failing auth until a server restart, and a deleted
+// or decommissioned Bambu row kept a ghost MQTT client alive that stole the
+// printer's single LAN slot from its replacement row (observed on a real farm as
+// two entries kicking each other offline in a loop).
+
+jest.mock('../drivers', () => ({
+  getDriver: jest.fn(),
+  dropConnection: jest.fn(),
+}));
+
+const request  = require('supertest');
+const express  = require('express');
+const Database = require('better-sqlite3');
+const { dropConnection } = require('../drivers');
+
+let db;
+let app;
+
+beforeAll(() => {
+  db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE printers (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      name              TEXT NOT NULL UNIQUE,
+      ip                TEXT NOT NULL,
+      api_key           TEXT NOT NULL DEFAULT '',
+      group_name        TEXT,
+      type              TEXT DEFAULT 'prusa',
+      model             TEXT NOT NULL,
+      status            TEXT DEFAULT 'UNKNOWN',
+      is_held           INTEGER DEFAULT 0,
+      is_active         INTEGER DEFAULT 1,
+      decommissioned_at INTEGER,
+      decommission_note TEXT,
+      serial_number     TEXT DEFAULT '',
+      loaded_material   TEXT,
+      loaded_color      TEXT,
+      created_at        INTEGER NOT NULL
+    );
+    CREATE TABLE printer_groups (name TEXT PRIMARY KEY, created_at INTEGER NOT NULL);
+    CREATE TABLE printer_models (model_id TEXT PRIMARY KEY, connector TEXT, display_name TEXT);
+    CREATE TABLE projects (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL,
+      status TEXT DEFAULT 'active', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE parts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, project_id INTEGER NOT NULL, name TEXT NOT NULL,
+      target_qty INTEGER NOT NULL, completed_qty INTEGER DEFAULT 0, status TEXT DEFAULT 'open',
+      created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, part_id INTEGER, printer_id INTEGER,
+      gcode_id INTEGER, parts_per_plate INTEGER, status TEXT DEFAULT 'queued',
+      started_at INTEGER, finished_at INTEGER, created_at INTEGER NOT NULL
+    );
+  `);
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/printers', require('../routes/printers')(db));
+});
+
+beforeEach(() => {
+  dropConnection.mockClear();
+  db.prepare('DELETE FROM printers').run();
+  db.prepare(`
+    INSERT INTO printers (id, name, ip, api_key, type, model, serial_number, created_at)
+    VALUES (1, 'Bambu_A', '192.168.1.50', 'OLDCODE1', 'bambu', 'p1s', 'SN001', ?)
+  `).run(Date.now());
+});
+
+describe('PUT /api/printers/:id', () => {
+  test('changing api_key drops the cached connection', async () => {
+    const res = await request(app).put('/api/printers/1').send({ api_key: 'NEWCODE1' });
+    expect(res.status).toBe(200);
+    expect(dropConnection).toHaveBeenCalledWith('bambu', 1);
+  });
+
+  test('changing ip drops the cached connection', async () => {
+    const res = await request(app).put('/api/printers/1').send({ ip: '192.168.1.99' });
+    expect(res.status).toBe(200);
+    expect(dropConnection).toHaveBeenCalledWith('bambu', 1);
+  });
+
+  test('changing serial_number drops the cached connection', async () => {
+    const res = await request(app).put('/api/printers/1').send({ serial_number: 'SN002' });
+    expect(res.status).toBe(200);
+    expect(dropConnection).toHaveBeenCalledWith('bambu', 1);
+  });
+
+  test('changing type drops the connection under the OLD type', async () => {
+    const res = await request(app).put('/api/printers/1').send({ type: 'klipper' });
+    expect(res.status).toBe(200);
+    expect(dropConnection).toHaveBeenCalledWith('bambu', 1);
+  });
+
+  test('renaming only does not drop the connection', async () => {
+    const res = await request(app).put('/api/printers/1').send({ name: 'Bambu_B' });
+    expect(res.status).toBe(200);
+    expect(dropConnection).not.toHaveBeenCalled();
+  });
+
+  test('changing loaded material/color only does not drop the connection', async () => {
+    const res = await request(app).put('/api/printers/1')
+      .send({ loaded_material: 'PETG', loaded_color: 'Black' });
+    expect(res.status).toBe(200);
+    expect(dropConnection).not.toHaveBeenCalled();
+  });
+
+  test('api_key null keeps the old value (COALESCE) and does not drop', async () => {
+    const res = await request(app).put('/api/printers/1').send({ api_key: null });
+    expect(res.status).toBe(200);
+    expect(res.body.api_key).toBe('OLDCODE1');
+    expect(dropConnection).not.toHaveBeenCalled();
+  });
+
+  test('sending the same api_key value does not drop', async () => {
+    const res = await request(app).put('/api/printers/1').send({ api_key: 'OLDCODE1' });
+    expect(res.status).toBe(200);
+    expect(dropConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/printers/:id', () => {
+  test('drops the cached connection so the client cannot reconnect forever', async () => {
+    const res = await request(app).delete('/api/printers/1');
+    expect(res.status).toBe(200);
+    expect(dropConnection).toHaveBeenCalledWith('bambu', 1);
+  });
+
+  test('404 for unknown printer does not drop anything', async () => {
+    const res = await request(app).delete('/api/printers/999');
+    expect(res.status).toBe(404);
+    expect(dropConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe('decommission paths', () => {
+  test('POST /:id/decommission drops the cached connection', async () => {
+    const res = await request(app).post('/api/printers/1/decommission').send({ note: 'retired' });
+    expect(res.status).toBe(200);
+    expect(dropConnection).toHaveBeenCalledWith('bambu', 1);
+  });
+
+  test('POST /:id/complete-and-decommission drops the cached connection', async () => {
+    const res = await request(app).post('/api/printers/1/complete-and-decommission').send({});
+    expect(res.status).toBe(200);
+    expect(dropConnection).toHaveBeenCalledWith('bambu', 1);
+  });
+
+  test('POST /:id/mark-job-failure with no tracked job drops the cached connection', async () => {
+    const res = await request(app).post('/api/printers/1/mark-job-failure').send({});
+    expect(res.status).toBe(200);
+    expect(dropConnection).toHaveBeenCalledWith('bambu', 1);
+  });
+
+  test('POST /:id/mark-job-failure with an active job drops the cached connection', async () => {
+    const now = Date.now();
+    db.prepare(`INSERT INTO projects (id, name, created_at, updated_at) VALUES (1, 'P', ?, ?)`).run(now, now);
+    db.prepare(`INSERT INTO parts (id, project_id, name, target_qty, created_at, updated_at)
+      VALUES (1, 1, 'Part', 5, ?, ?)`).run(now, now);
+    db.prepare(`INSERT INTO jobs (id, part_id, printer_id, parts_per_plate, status, started_at, created_at)
+      VALUES (1, 1, 1, 1, 'printing', ?, ?)`).run(now, now);
+
+    const res = await request(app).post('/api/printers/1/mark-job-failure').send({});
+    expect(res.status).toBe(200);
+    expect(dropConnection).toHaveBeenCalledWith('bambu', 1);
+  });
+});
+
+describe('drivers registry dropConnection helper', () => {
+  const registry = jest.requireActual('../drivers');
+
+  test('unknown type is a silent no-op', () => {
+    expect(() => registry.dropConnection('not-a-driver', 1)).not.toThrow();
+  });
+
+  test('a loaded driver without dropConnection is tolerated', () => {
+    registry.getDriver('prusa'); // request/response driver, no connection cache
+    expect(() => registry.dropConnection('prusa', 1)).not.toThrow();
+  });
+
+  test('a never-loaded driver is not loaded just to drop a connection', () => {
+    // klipper is lazily loaded and nothing in this test file has requested it;
+    // dropping must not force the require.
+    expect(() => registry.dropConnection('klipper', 1)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Persistent-connection drivers (bambu, elegoo-centauri, elegoo-centauri2) keep a module-level client per `printer.id` that auto-reconnects with the credentials it was created with. Nothing ever invalidated that cache, which produced two real-world failures on my farm (two P1S units):

1. **Credential edits need a restart.** I added a P1S with a mistyped access code, corrected it on the Settings page, and the printer stayed OFFLINE: the cached MQTT client kept retrying auth with the old code until the server restarted.
2. **Ghost clients from deleted/decommissioned rows.** A duplicate row for the same physical printer was decommissioned, but its MQTT client kept reconnecting forever. Bambu accepts a single LAN client, so the ghost and the live entry kicked each other offline in a loop that looked exactly like a flaky printer.

## How

- The three persistent drivers export their existing (previously unreachable) `dropConnection(printerId)` helpers.
- The registry gains `dropConnection(type, printerId)`. It only consults drivers already loaded (a never-loaded driver cannot hold a connection), so lazy loading is preserved, and it is a silent no-op for stateless drivers and unknown types.
- `routes/printers.js` calls it when `ip`, `api_key`, `serial_number`, or `type` changes on PUT (api_key compared against the request body since it is deliberately excluded from event logging), and on DELETE plus all three decommission paths. The next poll recreates the connection from the current row.

No part-count paths are touched.

## Test hardware

Validated on a real P1S (LAN mode + Developer Mode): set a wrong access code via PUT, the printer went OFFLINE within one poll; restored the correct code, it reconnected on the next poll with no restart. The elegoo-centauri/centauri2 exports are the same pattern but untested on hardware (I own no Elegoo).

## Tests

Full suite passes (29 suites, 450 tests, run in the dev Docker stage). New coverage: 3 driver tests (client ended, reconnect picks up fresh credentials, unknown-id no-op) and a route suite covering every path that must (and must not) drop, plus the registry helper's no-op guarantees. Docs: `driver-authoring.md` contract entry, `api.md` notes, dated changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)