### PR TITLE
fix(jobs): force-cancel escape hatch for stuck uploading/printing jobs

### DIFF
--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useConfirm } from '../useConfirm';
+import { useToast } from '../useToast';
 import EmptyState from '../components/EmptyState';
 
 // Colors match the Fleet page conventions: blue = printing, green = done.
@@ -56,6 +57,7 @@ const selectSx = {
 
 export default function Jobs() {
   const [confirm, confirmModal]   = useConfirm();
+  const [showToast, toastEl]      = useToast();
   const [jobs, setJobs]           = useState([]);
   const [loading, setLoading]     = useState(true);
   const [projects, setProjects]   = useState([]);
@@ -104,21 +106,42 @@ export default function Jobs() {
     return () => clearInterval(interval);
   }, [fetchJobs]);
 
-  async function cancelJob(jobId) {
-    const ok = await confirm({
+  // A stuck uploading/printing job (e.g. the printer silently ignored the
+  // print-start command) can be force-cancelled. This only clears the farm's
+  // job row: it never stops the printer itself, and a printer awaiting
+  // sign-off is resolved from Fleet, not here (the button is hidden for those).
+  function canCancel(job) {
+    if (job.status === 'queued') return true;
+    return (job.status === 'uploading' || job.status === 'printing')
+      && displayJobStatus(job) !== 'awaiting';
+  }
+
+  async function cancelJob(job) {
+    const force = job.status !== 'queued';
+    const ok = await confirm(force ? {
+      title: 'Force Cancel Job',
+      message: 'This clears the stuck job record so its part can be edited or re-queued. It does NOT stop the printer: if a print is physically running, stop it on the printer or resolve it from Fleet.',
+      confirmLabel: 'Force Cancel',
+      danger: true,
+    } : {
       title: 'Cancel Job',
       message: 'Remove this job from the queue?',
       confirmLabel: 'Cancel Job',
       danger: true,
     });
     if (!ok) return;
-    await fetch(`/api/jobs/${jobId}`, { method: 'DELETE' });
+    const res = await fetch(`/api/jobs/${job.id}${force ? '?force=true' : ''}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      showToast('Cancel failed: ' + (body.error || res.status), 'error');
+    }
     fetchJobs();
   }
 
   return (
     <div>
       {confirmModal}
+      {toastEl}
       <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 16 }}>Job Queue</h1>
 
       {/* Filters */}
@@ -187,12 +210,12 @@ export default function Jobs() {
                     {formatTime(job.started_at)}
                     {job.started_at && <> · {formatDuration(job.started_at, job.finished_at || null)}</>}
                   </span>
-                  {job.status === 'queued' && (
+                  {canCancel(job) && (
                     <button
-                      onClick={() => cancelJob(job.id)}
+                      onClick={() => cancelJob(job)}
                       style={{ background: '#7f1d1d', color: '#f87171', border: 'none', borderRadius: 4, padding: '5px 12px', fontSize: 12, fontWeight: 600, cursor: 'pointer' }}
                     >
-                      Cancel
+                      {job.status === 'queued' ? 'Cancel' : 'Force Cancel'}
                     </button>
                   )}
                 </div>
@@ -254,16 +277,16 @@ export default function Jobs() {
                         : '—'}
                     </td>
                     <td style={{ padding: '8px 10px' }}>
-                      {job.status === 'queued' && (
+                      {canCancel(job) && (
                         <button
-                          onClick={() => cancelJob(job.id)}
+                          onClick={() => cancelJob(job)}
                           style={{
                             background: '#7f1d1d', color: '#f87171', border: 'none',
                             borderRadius: 4, padding: '3px 10px', fontSize: 12,
-                            fontWeight: 600, cursor: 'pointer',
+                            fontWeight: 600, cursor: 'pointer', whiteSpace: 'nowrap',
                           }}
                         >
-                          Cancel
+                          {job.status === 'queued' ? 'Cancel' : 'Force Cancel'}
                         </button>
                       )}
                     </td>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,22 @@ Fixed by adding `priority ASC` to the dashboard's active-projects query, matchin
 - `server/tests/dashboard.test.js` (new): covers priority ordering, the `created_at` tiebreaker, and exclusion of non-active projects.
 - `docs/api.md`, `docs/web-app.md`: documented that `active_projects` and the Dashboard's Active Projects panel are ordered by priority, matching the Projects page.
 
+## 2026-07-24: stuck uploading/printing jobs can be force-cancelled from the Jobs page
+
+Reported from a live two-printer Bambu farm. A dispatch uploaded a file and published the print-start command, but the printer (latched on a previous FINISH state) silently never started it. The job row sat in `printing` forever against a machine that was not printing anything. That zombie row blocked part deletion (parts refuse to delete with an active job) and had no exit: the Jobs page cancel action only accepted `queued` jobs, and the only endpoint that could touch an active job, `mark-job-failure`, decommissions the printer as a side effect. The operator's actual fix was hand-editing the database.
+
+`DELETE /api/jobs/:id` now accepts `?force=true` to cancel an `uploading` or `printing` job. The scope is deliberately tiny: the job row becomes `cancelled` with `finished_at` stamped, and nothing else happens. No `completed_qty` credit (an active job has credited nothing yet), no hold release (holds are resolved through Fleet's Set Ready / Bad Print), no printer contact (a physically running print is stopped at the printer or from Fleet). The Jobs page shows a "Force Cancel" button on uploading/printing rows, with a danger confirm that says exactly that. Rows displaying as "Awaiting Sign-off" keep no cancel button: resolving a held printer by cancelling its job would bypass the operator sign-off flow.
+
+One interaction needed guarding: the scheduler marks a job `printing` after its upload settles. If the operator force-cancelled during the transfer (uploads retry for many seconds), that write would have resurrected the cancelled job. Both post-upload writes (normal completion and the checkIfPrinting recovery path) now update only `WHERE status = 'uploading'` and treat zero changed rows as "leave it cancelled".
+
+### Changes
+- `server/routes/jobs.js`: `force` query param on DELETE; `uploading`/`printing` become cancellable with `finished_at` stamped; the 409 for other statuses hints at force; queued path byte-for-byte unchanged.
+- `server/scheduler.js` (`_executeUpload`): both status-to-printing writes guard on `status = 'uploading'` and return null when the job was cancelled mid-upload; the recovery path no longer holds the printer in that case.
+- `client/src/pages/Jobs.jsx`: "Force Cancel" on uploading/printing rows (hidden for Awaiting Sign-off), distinct danger confirm, error toast on failed cancels.
+- `server/tests/jobs-cancel.test.js`: new suite covering both modes, part-count and hold invariants, and 409/404 semantics.
+- `server/tests/scheduler-file.test.js`: 2 new tests proving a mid-upload cancel survives both post-upload write paths.
+- `docs/api.md`, `docs/web-app.md`: endpoint and Jobs page behavior documented.
+
 ## 2026-07-04: fix adding a part to a completed project couldn't be reactivated
 
 Reported: adding a new part to a project that had already completed left the project stuck, clicking Re-activate returned "All parts are at target qty, adjust quantities first" even though the new part clearly had remaining qty (0/1).
@@ -60,6 +76,7 @@ Verified all three trigger points again, this time driven through the actual bro
 - `docs/api.md`: documented the reactivation/sweep behavior on `POST /api/parts`, `PUT /api/parts/:id`, and `POST /api/gcodes/upload`; corrected the `POST /api/parts` wording in round 3.
 
 ---
+
 ## 2026-07-12: dispatch_batch_size means concurrent uploads, not printers considered per pass
 
 Joel batch-confirmed a stack of held printers via Fleet's "Set Ready (N)" button with `dispatch_batch_size` set to 5, and instead of 5 uploads running at once he saw 3 or 4. He walked through it precisely: some of the held printers had the wrong material or color loaded for the part they'd match, so the scheduler correctly found "no candidate" for them and moved on without creating a job, exactly as designed. The bug was in what happened next. `_sweepInBatches` chunked the confirmed printers into fixed slices of `dispatch_batch_size` and processed one slice at a time, waiting for the whole slice to settle before moving to the next. If a slice of 5 had only 1 real candidate, only 1 upload ran, and the scheduler moved on to the *next fixed slice of 5* instead of reaching further into the queue to make up the difference. Joel's framing was the fix: "if I have five set as my limit, then five should be uploading at once, not five being contacted at once with one of the five being able to print."

--- a/docs/api.md
+++ b/docs/api.md
@@ -495,6 +495,12 @@ Single job with same joins, including `printer_is_held` and `printer_status`. `4
 
 Cancels a job. Returns `409` if status is not `queued` (only queued jobs can be cancelled).
 
+With `?force=true` (or `?force=1`), also cancels an `uploading` or `printing` job. This is the escape hatch for a stuck row, e.g. a printer that silently ignored the print-start command, leaving its job `printing` forever and blocking part deletion. Force-cancel updates only the job row (status `cancelled`, `finished_at` stamped): it never credits `completed_qty`, never clears a printer hold, and never contacts the printer. `finished` and `failed` jobs return `409` even with force.
+
+```json
+{ "success": true }
+```
+
 ---
 
 ## Scheduler

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -263,7 +263,7 @@ Live job queue that polls `GET /api/jobs` every 15 seconds.
 
 **Filters:** status dropdown (all / queued / uploading / printing / finished / failed / cancelled), project dropdown, printer dropdown, all passed as query params on each fetch. The dropdown filters on the real `jobs.status` column; "Awaiting Sign-off" below is a display-only badge, not a filterable value.
 
-**Actions:** "Cancel" button on `queued` rows → `DELETE /api/jobs/:id` with confirm dialog.
+**Actions:** "Cancel" button on `queued` rows → `DELETE /api/jobs/:id` with confirm dialog. "Force Cancel" button on `uploading`/`printing` rows → `DELETE /api/jobs/:id?force=true` with a danger confirm that spells out what it does and does not do: it clears the stuck job record only, it does not stop the printer. The button is hidden when the row displays as "Awaiting Sign-off" (printer held): those are resolved from Fleet via Set Ready / Bad Print, not by cancelling the job out from under the hold. Failed cancels surface via toast.
 
 **Status color coding:**
 

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -55,18 +55,42 @@ module.exports = (db) => {
     res.json(job);
   });
 
-  // DELETE /api/jobs/:id — cancel a queued job only
+  // DELETE /api/jobs/:id: cancel a queued job. With ?force=true, also cancel an
+  // uploading or printing job: the escape hatch for a stuck row, e.g. a dispatch
+  // whose print-start command the printer silently ignored, leaving a job
+  // 'printing' forever against an idle machine (and blocking part deletion).
+  //
+  // Force-cancel only touches the job row. It never credits completed_qty (an
+  // active job has credited nothing yet), never clears a printer hold (holds are
+  // resolved by the operator through Fleet's Set Ready / Bad Print), and never
+  // contacts the printer (if a print is physically running, stop it at the
+  // printer or from Fleet; the UI confirm says exactly that).
   router.delete('/:id', (req, res) => {
     const job = db.prepare('SELECT * FROM jobs WHERE id = ?').get(req.params.id);
     if (!job) return res.status(404).json({ error: 'Job not found' });
 
-    if (job.status !== 'queued') {
+    const force = req.query.force === 'true' || req.query.force === '1';
+    const cancellable = force ? ['queued', 'uploading', 'printing'] : ['queued'];
+
+    if (!cancellable.includes(job.status)) {
+      const hint = force
+        ? 'Only queued, uploading, or printing jobs can be cancelled.'
+        : 'Only queued jobs can be cancelled (pass ?force=true for a stuck uploading/printing job).';
       return res.status(409).json({
-        error: `Cannot cancel a job with status "${job.status}". Only queued jobs can be cancelled.`,
+        error: `Cannot cancel a job with status "${job.status}". ${hint}`,
       });
     }
 
-    db.prepare(`UPDATE jobs SET status = 'cancelled' WHERE id = ?`).run(req.params.id);
+    // finished_at is stamped on force-cancel to match the scheduler's own cancelled
+    // writes; operator flows (mark-job-failure) order cancelled jobs by finished_at.
+    // The queued path stays exactly as before.
+    if (job.status === 'queued') {
+      db.prepare(`UPDATE jobs SET status = 'cancelled' WHERE id = ?`).run(req.params.id);
+    } else {
+      db.prepare(`UPDATE jobs SET status = 'cancelled', finished_at = ? WHERE id = ?`)
+        .run(Date.now(), req.params.id);
+      console.log(`[jobs] Job ${job.id} force-cancelled by operator (was ${job.status})`);
+    }
     res.json({ success: true });
   });
 

--- a/server/scheduler.js
+++ b/server/scheduler.js
@@ -449,7 +449,16 @@ class JobScheduler extends EventEmitter {
       // the upload as a success so the job is tracked correctly.
       const isActuallyPrinting = await driver.checkIfPrinting(printer);
       if (isActuallyPrinting) {
-        this.db.prepare(`UPDATE jobs SET status = 'printing', started_at = ? WHERE id = ?`).run(Date.now(), jobId);
+        // Guard on 'uploading': the operator may have force-cancelled this job while
+        // the upload retried. A cancelled job must stay cancelled, not come back as
+        // 'printing' from a stale in-flight dispatch.
+        const recovered = this.db.prepare(
+          `UPDATE jobs SET status = 'printing', started_at = ? WHERE id = ? AND status = 'uploading'`
+        ).run(Date.now(), jobId);
+        if (recovered.changes === 0) {
+          console.log(`[scheduler] ${printer.name} job ${jobId} was cancelled during upload, leaving it cancelled`);
+          return null;
+        }
         console.log(`[scheduler] ${printer.name} upload appeared to fail but printer is printing — job ${jobId} recovered`);
         return jobId;
       }
@@ -467,9 +476,15 @@ class JobScheduler extends EventEmitter {
       return null;
     }
 
-    this.db.prepare(`
-      UPDATE jobs SET status = 'printing', started_at = ? WHERE id = ?
+    // Same guard as the recovery path above: if the operator force-cancelled the
+    // job while the file was transferring, do not resurrect it to 'printing'.
+    const started = this.db.prepare(`
+      UPDATE jobs SET status = 'printing', started_at = ? WHERE id = ? AND status = 'uploading'
     `).run(Date.now(), jobId);
+    if (started.changes === 0) {
+      console.log(`[scheduler] ${printer.name} job ${jobId} was cancelled during upload, leaving it cancelled`);
+      return null;
+    }
 
     console.log(`[scheduler] ${printer.name} ← ${candidate.filename}`);
     return jobId;

--- a/server/tests/jobs-cancel.test.js
+++ b/server/tests/jobs-cancel.test.js
@@ -1,0 +1,136 @@
+// Tests for DELETE /api/jobs/:id — queued cancel (existing behavior) and the
+// ?force=true escape hatch for stuck uploading/printing jobs.
+//
+// Regression context: a Bambu printer silently ignored a print-start command
+// (latched FINISH state), leaving its job 'printing' forever against an idle
+// machine. The stuck row blocked part deletion (parts refuse to delete with an
+// active job) and nothing in the UI could clear it: the cancel endpoint only
+// accepted queued jobs, and mark-job-failure would have decommissioned the
+// printer as a side effect. force=true cancels just the job row: it never
+// credits parts, never clears a printer hold, and never contacts the printer.
+
+const request  = require('supertest');
+const express  = require('express');
+const Database = require('better-sqlite3');
+
+let db;
+let app;
+
+beforeAll(() => {
+  db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE printers (id INTEGER PRIMARY KEY, name TEXT, ip TEXT, api_key TEXT DEFAULT '',
+      model TEXT, status TEXT DEFAULT 'UNKNOWN', is_held INTEGER DEFAULT 0,
+      is_active INTEGER DEFAULT 1, created_at INTEGER);
+    CREATE TABLE projects (id INTEGER PRIMARY KEY, name TEXT, status TEXT DEFAULT 'active',
+      created_at INTEGER, updated_at INTEGER);
+    CREATE TABLE parts (id INTEGER PRIMARY KEY, project_id INTEGER, name TEXT,
+      target_qty INTEGER, completed_qty INTEGER DEFAULT 0, status TEXT DEFAULT 'open',
+      created_at INTEGER, updated_at INTEGER);
+    CREATE TABLE jobs (id INTEGER PRIMARY KEY, part_id INTEGER, printer_id INTEGER,
+      gcode_id INTEGER, parts_per_plate INTEGER, status TEXT DEFAULT 'queued',
+      started_at INTEGER, finished_at INTEGER, created_at INTEGER);
+  `);
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/jobs', require('../routes/jobs')(db));
+});
+
+beforeEach(() => {
+  const now = Date.now();
+  db.prepare('DELETE FROM jobs').run();
+  db.prepare('DELETE FROM parts').run();
+  db.prepare('DELETE FROM projects').run();
+  db.prepare('DELETE FROM printers').run();
+  db.prepare(`INSERT INTO printers (id, name, ip, model, status, is_held, created_at)
+    VALUES (1, 'P1', '192.168.1.1', 'p1s', 'FINISHED', 1, ?)`).run(now);
+  db.prepare(`INSERT INTO projects (id, name, created_at, updated_at) VALUES (1, 'Proj', ?, ?)`).run(now, now);
+  db.prepare(`INSERT INTO parts (id, project_id, name, target_qty, completed_qty, created_at, updated_at)
+    VALUES (1, 1, 'Part', 10, 3, ?, ?)`).run(now, now);
+});
+
+function insertJob(status, { startedAt = Date.now() } = {}) {
+  const result = db.prepare(`
+    INSERT INTO jobs (part_id, printer_id, parts_per_plate, status, started_at, created_at)
+    VALUES (1, 1, 2, ?, ?, ?)
+  `).run(status, startedAt, Date.now());
+  return result.lastInsertRowid;
+}
+
+describe('DELETE /api/jobs/:id without force (existing behavior)', () => {
+  test('cancels a queued job', async () => {
+    const id = insertJob('queued');
+    const res = await request(app).delete(`/api/jobs/${id}`);
+    expect(res.status).toBe(200);
+    expect(db.prepare('SELECT status FROM jobs WHERE id = ?').get(id).status).toBe('cancelled');
+  });
+
+  test('queued cancel does not stamp finished_at (unchanged behavior)', async () => {
+    const id = insertJob('queued');
+    await request(app).delete(`/api/jobs/${id}`);
+    expect(db.prepare('SELECT finished_at FROM jobs WHERE id = ?').get(id).finished_at).toBeNull();
+  });
+
+  test('409 for a printing job, with a hint about force', async () => {
+    const id = insertJob('printing');
+    const res = await request(app).delete(`/api/jobs/${id}`);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/force=true/);
+    expect(db.prepare('SELECT status FROM jobs WHERE id = ?').get(id).status).toBe('printing');
+  });
+
+  test('404 for unknown job', async () => {
+    const res = await request(app).delete('/api/jobs/999');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/jobs/:id?force=true', () => {
+  test('cancels a printing job and stamps finished_at', async () => {
+    const id = insertJob('printing');
+    const res = await request(app).delete(`/api/jobs/${id}?force=true`);
+    expect(res.status).toBe(200);
+    const job = db.prepare('SELECT status, finished_at FROM jobs WHERE id = ?').get(id);
+    expect(job.status).toBe('cancelled');
+    expect(job.finished_at).not.toBeNull();
+  });
+
+  test('cancels an uploading job', async () => {
+    const id = insertJob('uploading');
+    const res = await request(app).delete(`/api/jobs/${id}?force=true`);
+    expect(res.status).toBe(200);
+    expect(db.prepare('SELECT status FROM jobs WHERE id = ?').get(id).status).toBe('cancelled');
+  });
+
+  test('force=1 is accepted as well', async () => {
+    const id = insertJob('printing');
+    const res = await request(app).delete(`/api/jobs/${id}?force=1`);
+    expect(res.status).toBe(200);
+  });
+
+  test('never touches completed_qty (part counts are sacred)', async () => {
+    const id = insertJob('printing');
+    await request(app).delete(`/api/jobs/${id}?force=true`);
+    expect(db.prepare('SELECT completed_qty FROM parts WHERE id = 1').get().completed_qty).toBe(3);
+  });
+
+  test('never clears the printer hold (holds are resolved via Fleet)', async () => {
+    const id = insertJob('printing');
+    await request(app).delete(`/api/jobs/${id}?force=true`);
+    expect(db.prepare('SELECT is_held FROM printers WHERE id = 1').get().is_held).toBe(1);
+  });
+
+  test('409 even with force for a finished job', async () => {
+    const id = insertJob('finished');
+    const res = await request(app).delete(`/api/jobs/${id}?force=true`);
+    expect(res.status).toBe(409);
+    expect(db.prepare('SELECT status FROM jobs WHERE id = ?').get(id).status).toBe('finished');
+  });
+
+  test('409 even with force for a failed job', async () => {
+    const id = insertJob('failed');
+    const res = await request(app).delete(`/api/jobs/${id}?force=true`);
+    expect(res.status).toBe(409);
+  });
+});

--- a/server/tests/scheduler-file.test.js
+++ b/server/tests/scheduler-file.test.js
@@ -319,6 +319,66 @@ describe('_dispatchToPrinter — upload failure recovery', () => {
   });
 });
 
+// ─── Force-cancel during upload ───────────────────────────────────────────────
+// An operator can force-cancel a stuck uploading job (DELETE /api/jobs/:id?force=true).
+// The dispatch that is still in flight for that job must not overwrite 'cancelled'
+// back to 'printing' when its upload settles.
+
+describe('_dispatchToPrinter: job force-cancelled during upload', () => {
+  beforeEach(() => { jest.useFakeTimers(); });
+
+  // Simulates the operator force-cancelling while the transfer is in flight.
+  function cancelActiveJob(db) {
+    db.prepare(
+      "UPDATE jobs SET status = 'cancelled', finished_at = ? WHERE status = 'uploading'"
+    ).run(Date.now());
+  }
+
+  test('successful upload does not resurrect a cancelled job to printing', async () => {
+    const filename = `cancel_mid_${Date.now()}.bgcode`;
+    createTestFile(filename);
+    const db = makeDb(filename);
+    const scheduler = new JobScheduler(db, { on: () => {} });
+
+    mockDriver.uploadAndPrint.mockImplementation(async () => cancelActiveJob(db));
+
+    const promise = scheduler._dispatchToPrinter(fakePrinter);
+    await jest.runAllTimersAsync();
+    const jobId = await promise;
+
+    expect(jobId).toBeNull();
+    const job = db.prepare('SELECT status FROM jobs ORDER BY id DESC LIMIT 1').get();
+    expect(job.status).toBe('cancelled');
+  });
+
+  test('checkIfPrinting recovery path does not resurrect a cancelled job', async () => {
+    const filename = `cancel_recover_${Date.now()}.bgcode`;
+    createTestFile(filename);
+    const db = makeDb(filename);
+    const scheduler = new JobScheduler(db, { on: () => {} });
+
+    // Every upload attempt fails; the operator cancels during the retries; the
+    // printer happens to be printing (e.g. a print started outside the farm).
+    mockDriver.uploadAndPrint.mockImplementation(async () => {
+      cancelActiveJob(db);
+      throw new Error('ETIMEDOUT');
+    });
+    mockDriver.checkIfPrinting.mockResolvedValue(true);
+
+    const promise = scheduler._dispatchToPrinter(fakePrinter);
+    await jest.runAllTimersAsync();
+    const jobId = await promise;
+
+    expect(jobId).toBeNull();
+    const job = db.prepare('SELECT status FROM jobs ORDER BY id DESC LIMIT 1').get();
+    expect(job.status).toBe('cancelled');
+    // The recovery path must not hold the printer either: the operator already
+    // resolved this job by cancelling it.
+    const printer = db.prepare('SELECT is_held FROM printers WHERE id = 1').get();
+    expect(printer.is_held).toBe(0);
+  });
+});
+
 // ─── Upload lock ──────────────────────────────────────────────────────────────
 // _activeUploads prevents a second concurrent dispatch to the same printer while
 // an upload is still in flight. Without this guard, a slow transfer could cause


### PR DESCRIPTION
## What

On my farm, a P1S latched on a previous FINISH state silently ignored a `project_file` print-start command. The upload succeeded, so the job row went to `printing` and stayed there forever against a machine that was not printing anything. That zombie row blocked part deletion (parts refuse to delete with an active job) and had no exit from the UI: the cancel endpoint only accepts `queued` jobs, and `mark-job-failure` decommissions the printer as a side effect. My actual fix at the time was editing the database by hand.

## How

`DELETE /api/jobs/:id?force=true` now also cancels `uploading`/`printing` jobs. Scope is deliberately tiny, per the operator-safety model:

- The job row becomes `cancelled` with `finished_at` stamped. Nothing else happens.
- **No `completed_qty` credit**: an active job has credited nothing yet, so cancelling it cannot double-fire or phantom-credit anything; the fields are never touched (asserted in tests).
- **No hold release**: printers awaiting sign-off are resolved through Fleet's Set Ready / Bad Print. The Jobs page hides the button on rows displaying as Awaiting Sign-off for the same reason.
- **No printer contact**: the danger confirm states plainly that a physically running print must be stopped at the printer or resolved from Fleet.

One interaction needed guarding: the scheduler marks a job `printing` after its upload settles, which would resurrect a job force-cancelled mid-transfer (uploads retry for many seconds). Both post-upload writes now guard on `WHERE status = 'uploading'` and treat zero changed rows as "leave it cancelled"; the checkIfPrinting recovery path also no longer holds the printer in that case, since the operator already resolved the job. The queued cancel path is byte-for-byte unchanged.

## UI

"Force Cancel" button on uploading/printing rows in both the table and the mobile card layout, distinct danger confirm via `useConfirm`, failed cancels surfaced via `useToast`. `npm run build` passes.

## Test hardware

The stuck-job scenario was hit on a real P1S; the code change itself is server/UI logic with no driver work, so no hardware matrix applies.

## Tests

Full suite passes (29 suites, 443 tests, run in the dev Docker stage). New coverage: a route suite for both modes (including the part-count and hold invariants above, and 409-even-with-force for finished/failed jobs) and 2 scheduler tests proving a mid-upload cancel survives both post-upload write paths. Docs: `api.md`, `web-app.md`, dated changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)