### PR TITLE
fix(drivers): drop cached connection on decommission to stop reconnect flood (#45)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ---
 
+## 2026-08-02: stop a decommissioned printer's driver from reconnecting forever (issue #45)
+
+Issue #45 reported that a decommissioned Bambu printer kept flooding the logs with "connected, reconnected, etc" every few seconds. Root cause: Bambu (MQTT) and Elegoo Centauri/Centauri 2 (websocket) drivers each hold a persistent connection per printer in a module-level `Map`, and nothing ever removed the entry when a printer was decommissioned. The poller stops calling `getStatus` for a decommissioned printer (it only queries `is_active = 1`), but the underlying MQTT/websocket client library keeps retrying on its own reconnect timer regardless, since the connection object itself was never told to close.
+
+Every code path that sets `is_active = 0` now drops the printer's cached connection immediately: `decommission`, `complete-and-decommission`, and both branches of `mark-job-failure`. Stateless request/response drivers (Prusa, Klipper, OctoPrint) have nothing to drop and are unaffected. Driver code was exercised against mocks only; not yet validated against real Bambu or Elegoo hardware.
+
+### Changes
+- `server/drivers/bambu.js`, `server/drivers/elegoo-centauri.js`, `server/drivers/elegoo-centauri2.js`: exported the existing internal `dropConnection` function so it can be called from outside the driver.
+- `server/drivers/index.js`: added a `dropConnection(printer)` registry helper that looks up the printer's driver and calls its `dropConnection` if it has one; a no-op for stateless drivers and safe against an unknown printer type.
+- `server/routes/printers.js`: all four code paths that set `is_active = 0` (`decommission`, `complete-and-decommission`, `mark-job-failure`'s two branches) now call the new `dropConnection` helper.
+- `docs/api.md`: noted the connection-drop side effect on the three decommission endpoints.
+- `docs/driver-authoring.md`: added `dropConnection(printerId)` to the documented optional driver exports.
+- `server/tests/printers-connection-cleanup.test.js` (new): regression test for issue #45, asserting all four decommission code paths drop the driver connection cache.
+
 ## 2026-07-30: Projects page only shows Active projects by default
 
 Joel noticed the Projects page listed every project regardless of status, so a farm with a long history of finished and shelved work buried the projects actually in flight. Now only `active` projects show by default; `draft`, `paused`, and `completed` are each hidden behind their own "Show X (count)" checkbox above the list, and a checkbox only appears when at least one project has that status. State persists per browser via `localStorage`, matching the existing "Show decommissioned" pattern on the Printers page. If every project ends up filtered out, an empty-state prompts to check a box instead of showing the misleading first-run "create your first project" message.

--- a/docs/api.md
+++ b/docs/api.md
@@ -129,7 +129,7 @@ Returns the updated printer object.
 
 ### `POST /api/printers/:id/decommission`
 
-Removes the printer from active duty (`is_active = 0`). It will no longer be polled or receive jobs. Returns the updated printer object.
+Removes the printer from active duty (`is_active = 0`). It will no longer be polled or receive jobs. Any cached driver connection (Bambu MQTT, Elegoo Centauri websocket) is dropped so the underlying client stops retrying in the background. Returns the updated printer object.
 
 ### `POST /api/printers/:id/complete-and-decommission`
 
@@ -137,6 +137,8 @@ Operator confirms the last print was successful, then takes the machine offline 
 
 - **Normal case** (job already in `finished` status): `_handleFinished` already credited `completed_qty`; nothing is re-credited. The printer is simply decommissioned.
 - **Missed-finish case** (job still in `printing` status): credits `completed_qty` by `parts_per_plate`, marks the job `finished`, and closes the Part / Project if targets are met — same logic as `set-ready`, but ending in decommission rather than dispatch.
+
+Also drops any cached driver connection for the printer, same as decommission.
 
 Returns the updated printer object.
 
@@ -148,7 +150,7 @@ The dispatched job is marked `printing` before the next poll has updated the pri
 
 ### `POST /api/printers/:id/mark-job-failure`
 
-Marks the printer's most relevant active or recently-completed job as `failed`, undoes the `completed_qty` increment if needed, reopens the Part and Project if needed, and decommissions the printer (`is_active = 0`).
+Marks the printer's most relevant active or recently-completed job as `failed`, undoes the `completed_qty` increment if needed, reopens the Part and Project if needed, and decommissions the printer (`is_active = 0`, dropping any cached driver connection same as decommission).
 
 **Job selection — two-query priority:**
 

--- a/docs/driver-authoring.md
+++ b/docs/driver-authoring.md
@@ -47,6 +47,15 @@ deleteFile(printer, filename)
   → if exported, the scheduler calls it after a job finishes to clean the
     file off the printer's storage (see bambu.js). Fire-and-forget: errors
     are swallowed by the caller.
+
+dropConnection(printerId)
+  → if your driver holds a persistent connection (see the pattern below),
+    export this to close it and remove it from your module-level Map. The
+    registry (server/drivers/index.js) calls it through printers.js whenever
+    a printer is decommissioned or deleted, so a stateful driver doesn't
+    keep reconnecting to hardware nobody expects to answer. Stateless
+    request/response drivers (Prusa, Klipper, OctoPrint) have no connection
+    to drop and should not export this.
 ```
 
 ### The `printer` row

--- a/server/drivers/bambu.js
+++ b/server/drivers/bambu.js
@@ -382,4 +382,4 @@ async function checkIfPrinting(printer) {
   return status === 'PRINTING' || status === 'PAUSED';
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, getAmsSlots, deleteFile };
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, getAmsSlots, deleteFile, dropConnection };

--- a/server/drivers/elegoo-centauri.js
+++ b/server/drivers/elegoo-centauri.js
@@ -227,4 +227,4 @@ async function checkIfPrinting(printer) {
   }
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting };
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, dropConnection };

--- a/server/drivers/elegoo-centauri2.js
+++ b/server/drivers/elegoo-centauri2.js
@@ -392,4 +392,4 @@ async function checkIfPrinting(printer) {
   }
 }
 
-module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting };
+module.exports = { getStatus, uploadAndPrint, cancelJob, checkIfPrinting, dropConnection };

--- a/server/drivers/index.js
+++ b/server/drivers/index.js
@@ -21,4 +21,15 @@ function getDriver(type) {
   return load();
 }
 
-module.exports = { getDriver };
+// Closes and forgets any persistent connection (Bambu MQTT, Elegoo Centauri
+// websocket) held for this printer. Stateless request/response drivers
+// (Prusa, Klipper, OctoPrint) have no dropConnection export, so this is a
+// no-op for them. Best-effort: an unregistered or unknown printer type must
+// never block the decommission or delete flow that calls this.
+function dropConnection(printer) {
+  try {
+    getDriver(printer.type).dropConnection?.(printer.id);
+  } catch (_) {}
+}
+
+module.exports = { getDriver, dropConnection };

--- a/server/routes/printers.js
+++ b/server/routes/printers.js
@@ -4,6 +4,7 @@ const Papa = require('papaparse');
 const axios = require('axios');
 const router = express.Router();
 const events = require('../events');
+const { dropConnection } = require('../drivers');
 
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -242,6 +243,9 @@ module.exports = (db) => {
     const now = Date.now();
     db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ? WHERE id = ?').run(now, printer.id);
     events.insert(printer.id, 'decommission', req.body?.note ?? null);
+    // Stop the driver's background reconnect loop: a decommissioned printer
+    // must not keep flooding logs trying to reach hardware nobody expects to answer.
+    dropConnection(printer);
     console.log(`[printers] ${printer.name} decommissioned`);
     res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
   });
@@ -323,6 +327,7 @@ module.exports = (db) => {
     const decommNote = req.body?.note ?? null;
     db.prepare('UPDATE printers SET is_active = 0, is_held = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, decommNote, printer.id);
     events.insert(printer.id, 'decommission', decommNote ?? 'operator confirmed successful print — taken offline for maintenance');
+    dropConnection(printer);
     console.log(`[printers] ${printer.name} decommissioned after confirmed good print`);
     res.json(db.prepare('SELECT * FROM printers WHERE id = ?').get(printer.id));
   });
@@ -378,6 +383,7 @@ module.exports = (db) => {
       const noJobNote = req.body?.note ?? null;
       db.prepare('UPDATE printers SET is_active = 0, decommissioned_at = ?, decommission_note = ? WHERE id = ?').run(now, noJobNote, printer.id);
       events.insert(printer.id, 'job_failed', noJobNote ?? 'No tracked job — printer decommissioned for investigation');
+      dropConnection(printer);
       console.log(`[printers] ${printer.name} decommissioned (no tracked job to mark failed)`);
       return res.json({ success: true, job_id: null });
     }
@@ -418,6 +424,7 @@ module.exports = (db) => {
       ? `Job ${job.id} — part: ${failedPart?.name ?? 'unknown'} — ${failNote}`
       : `Job ${job.id} — part: ${failedPart?.name ?? 'unknown'}`;
     events.insert(printer.id, 'job_failed', eventNote);
+    dropConnection(printer);
 
     console.log(`[printers] Job ${job.id} marked failed — ${printer.name} decommissioned pending investigation`);
     res.json({ success: true, job_id: job.id });

--- a/server/tests/printers-connection-cleanup.test.js
+++ b/server/tests/printers-connection-cleanup.test.js
@@ -1,0 +1,191 @@
+// Regression test for GitHub issue #45: a decommissioned printer kept its
+// persistent driver connection (Bambu MQTT, Elegoo websocket) alive, so the
+// underlying client library kept reconnecting and flooding logs forever
+// after decommission. Every code path that sets is_active = 0 must drop the
+// connection cache. Uses an in-memory SQLite DB; the driver registry and
+// event log are mocked so no real network connection is opened.
+
+const request  = require('supertest');
+const express  = require('express');
+const Database = require('better-sqlite3');
+
+jest.mock('../drivers', () => ({
+  getDriver: jest.fn(),
+  dropConnection: jest.fn(),
+}));
+jest.mock('../events', () => ({ insert: jest.fn() }));
+
+const { dropConnection } = require('../drivers');
+
+let db;
+let app;
+
+beforeAll(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE printers (
+      id               INTEGER PRIMARY KEY AUTOINCREMENT,
+      name             TEXT NOT NULL UNIQUE,
+      ip               TEXT NOT NULL,
+      api_key          TEXT NOT NULL DEFAULT '',
+      group_name       TEXT,
+      type             TEXT DEFAULT 'prusa',
+      model            TEXT NOT NULL,
+      status           TEXT DEFAULT 'UNKNOWN',
+      is_held          INTEGER DEFAULT 1,
+      is_active        INTEGER DEFAULT 1,
+      decommissioned_at INTEGER,
+      decommission_note TEXT,
+      serial_number    TEXT DEFAULT '',
+      created_at       INTEGER NOT NULL
+    );
+    CREATE TABLE projects (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      status TEXT DEFAULT 'active',
+      priority INTEGER DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE parts (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      project_id    INTEGER NOT NULL REFERENCES projects(id),
+      name          TEXT NOT NULL,
+      target_qty    INTEGER NOT NULL,
+      completed_qty INTEGER DEFAULT 0,
+      status        TEXT DEFAULT 'open',
+      sort_order    INTEGER DEFAULT 0,
+      created_at    INTEGER NOT NULL,
+      updated_at    INTEGER NOT NULL
+    );
+    CREATE TABLE gcodes (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      part_id         INTEGER NOT NULL REFERENCES parts(id),
+      printer_model   TEXT NOT NULL,
+      filename        TEXT NOT NULL,
+      filepath        TEXT NOT NULL,
+      parts_per_plate INTEGER NOT NULL,
+      est_print_secs  INTEGER,
+      created_at      INTEGER NOT NULL
+    );
+    CREATE TABLE jobs (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      part_id         INTEGER NOT NULL REFERENCES parts(id),
+      printer_id      INTEGER NOT NULL REFERENCES printers(id),
+      gcode_id        INTEGER NOT NULL REFERENCES gcodes(id),
+      parts_per_plate INTEGER NOT NULL,
+      status          TEXT DEFAULT 'queued',
+      started_at      INTEGER,
+      finished_at     INTEGER,
+      created_at      INTEGER NOT NULL
+    );
+    CREATE TABLE printer_models (
+      model_id  TEXT PRIMARY KEY,
+      label     TEXT NOT NULL,
+      connector TEXT NOT NULL
+    );
+    CREATE TABLE printer_groups (
+      name       TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL
+    );
+  `);
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/printers', require('../routes/printers')(db));
+});
+
+beforeEach(() => {
+  dropConnection.mockClear();
+});
+
+function seedPrinter(overrides = {}) {
+  const now = Date.now();
+  const r = db.prepare(`
+    INSERT INTO printers (name, ip, type, model, status, is_held, is_active, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    overrides.name    ?? `Printer_${now}_${Math.random()}`,
+    overrides.ip      ?? '10.0.0.1',
+    overrides.type    ?? 'bambu',
+    overrides.model   ?? 'x1c',
+    overrides.status  ?? 'FINISHED',
+    overrides.is_held  ?? 1,
+    overrides.is_active ?? 1,
+    now
+  );
+  return r.lastInsertRowid;
+}
+
+function seedProject() {
+  const now = Date.now();
+  return db.prepare(
+    `INSERT INTO projects (name, status, created_at, updated_at) VALUES ('Test Project', 'active', ?, ?)`
+  ).run(now, now).lastInsertRowid;
+}
+
+function seedPart(projectId, targetQty = 10, completedQty = 0) {
+  const now = Date.now();
+  return db.prepare(
+    `INSERT INTO parts (project_id, name, target_qty, completed_qty, status, created_at, updated_at)
+     VALUES (?, 'Test Part', ?, ?, 'open', ?, ?)`
+  ).run(projectId, targetQty, completedQty, now, now).lastInsertRowid;
+}
+
+function seedGcode(partId) {
+  const now = Date.now();
+  return db.prepare(
+    `INSERT INTO gcodes (part_id, printer_model, filename, filepath, parts_per_plate, created_at)
+     VALUES (?, 'x1c', 'part.3mf', '/fake/path/part.3mf', 4, ?)`
+  ).run(partId, now).lastInsertRowid;
+}
+
+function seedJob(printerId, partId, gcodeId, status = 'finished', partsPerPlate = 4) {
+  const now = Date.now();
+  return db.prepare(
+    `INSERT INTO jobs (printer_id, part_id, gcode_id, parts_per_plate, status, started_at, finished_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(printerId, partId, gcodeId, partsPerPlate, status, now - 3600000, status === 'finished' ? now : null, now - 3600000)
+    .lastInsertRowid;
+}
+
+test('POST /:id/decommission drops the driver connection cache', async () => {
+  const printerId = seedPrinter();
+
+  const res = await request(app).post(`/api/printers/${printerId}/decommission`);
+  expect(res.status).toBe(200);
+  expect(dropConnection).toHaveBeenCalledWith(expect.objectContaining({ id: printerId }));
+});
+
+test('POST /:id/complete-and-decommission drops the driver connection cache', async () => {
+  const projectId = seedProject();
+  const partId    = seedPart(projectId, 10, 4);
+  const gcodeId   = seedGcode(partId);
+  const printerId = seedPrinter();
+  seedJob(printerId, partId, gcodeId, 'finished', 4);
+
+  const res = await request(app).post(`/api/printers/${printerId}/complete-and-decommission`);
+  expect(res.status).toBe(200);
+  expect(dropConnection).toHaveBeenCalledWith(expect.objectContaining({ id: printerId }));
+});
+
+test('POST /:id/mark-job-failure drops the driver connection cache (no tracked job)', async () => {
+  const printerId = seedPrinter();
+
+  const res = await request(app).post(`/api/printers/${printerId}/mark-job-failure`);
+  expect(res.status).toBe(200);
+  expect(dropConnection).toHaveBeenCalledWith(expect.objectContaining({ id: printerId }));
+});
+
+test('POST /:id/mark-job-failure drops the driver connection cache (tracked job failed)', async () => {
+  const projectId = seedProject();
+  const partId    = seedPart(projectId, 10, 4);
+  const gcodeId   = seedGcode(partId);
+  const printerId = seedPrinter();
+  seedJob(printerId, partId, gcodeId, 'finished', 4);
+
+  const res = await request(app).post(`/api/printers/${printerId}/mark-job-failure`);
+  expect(res.status).toBe(200);
+  expect(dropConnection).toHaveBeenCalledWith(expect.objectContaining({ id: printerId }));
+});


### PR DESCRIPTION
## Summary
- Fixes #45. A decommissioned printer's persistent driver connection (Bambu MQTT, Elegoo Centauri/Centauri 2 websocket) was never closed, so the underlying client library kept retrying on its own reconnect timer forever, flooding the logs with "connected, reconnected, etc" every few seconds even though the printer was decommissioned.
- Root cause: the poller stops calling `getStatus` for a decommissioned printer (it only queries `is_active = 1`), but the connection object itself, cached in a module-level `Map` keyed by `printer.id`, was never told to close. The MQTT/websocket client library doesn't know or care that the printer went offline in our DB.
- Every code path that sets `is_active = 0` now drops the printer's cached connection immediately: `decommission`, `complete-and-decommission`, and both branches of `mark-job-failure`. Stateless request/response drivers (Prusa, Klipper, OctoPrint) have nothing to drop and are unaffected.

Driver code was exercised against mocks only; not yet validated against real Bambu or Elegoo hardware.

## Changes
- `server/drivers/bambu.js`, `server/drivers/elegoo-centauri.js`, `server/drivers/elegoo-centauri2.js`: exported the existing internal `dropConnection` function so it can be called from outside the driver.
- `server/drivers/index.js`: added a `dropConnection(printer)` registry helper that looks up the printer's driver and calls its `dropConnection` if it has one; a no-op for stateless drivers and safe against an unknown printer type.
- `server/routes/printers.js`: all four code paths that set `is_active = 0` now call the new `dropConnection` helper.
- `docs/api.md`: noted the connection-drop side effect on the three decommission endpoints.
- `docs/driver-authoring.md`: added `dropConnection(printerId)` to the documented optional driver exports.
- `docs/CHANGELOG.md`: dated entry.
- `server/tests/printers-connection-cleanup.test.js` (new): regression test for #45, asserting all four decommission code paths drop the driver connection cache.

## Test plan
- [x] `npm test` passes in full against this branch (32 suites, 449 tests)
- [ ] Hardware validation on a real Bambu or Elegoo printer (not yet done, flagged in the changelog entry)